### PR TITLE
Fix #17: UI: Display logged-in username in navigation header

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -142,6 +142,15 @@ header select option {
   gap: 15px; 
 }
 
+.header-username {
+  color: rgba(255, 255, 255, 0.85);
+  font-size: 13px;
+  font-weight: 500;
+  margin-right: 8px;
+  white-space: nowrap;
+  vertical-align: middle;
+}
+
 .btn-logout {
   background: transparent;
   border: 1px solid rgba(255,255,255,0.4);

--- a/templates/template.php
+++ b/templates/template.php
@@ -64,6 +64,10 @@
 
         <a href="/admin/index.php" title="Admin" style="text-decoration: none; font-size: 20px; margin-right: 15px; vertical-align: middle; display: inline-block; transition: opacity 0.2s;">⚙️</a>
 
+        <?php if (isset($_SESSION['username'])): ?>
+            <span class="header-username"><?php echo htmlspecialchars($_SESSION['username']); ?></span>
+        <?php endif; ?>
+
         <button onclick="window.location.href='logout.php'" class="btn-logout">
             Logout
         </button>


### PR DESCRIPTION
## Summary

Display the logged-in username in the navigation header by adding a username element next to the Logout link in the base template and styling it with CSS.

## Approach

1. In templates/template.php, locate the header section where the 'Logout' link is rendered. Add a new span/element immediately before the logout link that displays the username from $_SESSION['username'], using htmlspecialchars() for XSS protection. Wrap it in a conditional check to only show when the session variable is set. 2. In assets/css/styles.css, add styling for the new username element to ensure it is properly aligned in the top-right corner, has adequate right margin/spacing from the logout link, and is clearly legible (appropriate font color, size, and weight).

## Files Changed

- `templates/template.php`
- `assets/css/styles.css`

## Related Issue

Fixes #17

## Testing

No tests were added with this change. Happy to add them if needed.
