### PR TITLE
feat: add table statistics widget with WHERE row count support

### DIFF
--- a/admin/api.php
+++ b/admin/api.php
@@ -167,7 +167,7 @@ if ($action === 'health') {
             $db_error = '';
             pg_close($conn);
         }
-    } catch (Exception $e) {
+    } catch (Throwable $e) {
         $db_error = $e->getMessage();
     }
 
@@ -285,6 +285,77 @@ if ($action === 'list_icons') {
     }
     header('Content-Type: application/json');
     echo json_encode(['status' => 'success', 'icons' => array_values(array_unique($icons))]);
+    exit;
+}
+
+// Return total rows for the dashboard main table with optional WHERE clause
+if ($action === 'dashboard_main_table_count') {
+    header('Content-Type: application/json');
+    try {
+        require_once __DIR__ . '/../includes/db.php';
+        $conn = db_connect();
+
+        $tableName = trim($_GET['table'] ?? '');
+        $schemaName = trim($_GET['schema_name'] ?? 'public');
+        $whereClause = trim($_GET['where'] ?? '');
+
+        if (!preg_match('/^[a-zA-Z_][a-zA-Z0-9_]*$/', $tableName)) {
+            http_response_code(400);
+            echo json_encode(['status' => 'error', 'error' => 'Invalid table name.']);
+            exit;
+        }
+
+        if (!preg_match('/^[a-zA-Z_][a-zA-Z0-9_]*$/', $schemaName)) {
+            http_response_code(400);
+            echo json_encode(['status' => 'error', 'error' => 'Invalid schema name.']);
+            exit;
+        }
+
+        if ($whereClause !== '') {
+            $hasSqlComment = str_contains($whereClause, '--') || str_contains($whereClause, '/*') || str_contains($whereClause, '*/');
+            $hasDangerousKeyword = preg_match('/\b(INSERT|UPDATE|DELETE|DROP|ALTER|CREATE|TRUNCATE|GRANT|REVOKE)\b/i', $whereClause) === 1;
+            $hasInvalidChars = preg_match('/^[a-zA-Z0-9_\s\(\)\.=!<>",\'\-\+:%\/]+$/', $whereClause) !== 1;
+            $hasSemicolon = str_contains($whereClause, ';');
+
+            if ($hasSqlComment || $hasDangerousKeyword || $hasInvalidChars || $hasSemicolon) {
+                http_response_code(400);
+                echo json_encode(['status' => 'error', 'error' => 'Invalid WHERE clause.']);
+                exit;
+            }
+        }
+
+        $tableCheckSql = "SELECT 1 FROM information_schema.tables WHERE table_schema = $1 AND table_name = $2 LIMIT 1";
+        $tableCheckRes = @pg_query_params($conn, $tableCheckSql, [$schemaName, $tableName]);
+        if (!$tableCheckRes || pg_num_rows($tableCheckRes) === 0) {
+            http_response_code(404);
+            echo json_encode(['status' => 'error', 'error' => 'Table not found.']);
+            exit;
+        }
+
+        $safeSchema = pg_escape_identifier($conn, $schemaName);
+        $safeTable = pg_escape_identifier($conn, $tableName);
+        $sql = "SELECT COUNT(*) AS total_rows FROM $safeSchema.$safeTable";
+        if ($whereClause !== '') {
+            $sql .= " WHERE $whereClause";
+        }
+
+        $res = @pg_query($conn, $sql);
+        if (!$res) {
+            throw new Exception(pg_last_error($conn));
+        }
+
+        $row = pg_fetch_assoc($res);
+        echo json_encode([
+            'status' => 'success',
+            'schema' => $schemaName,
+            'table' => $tableName,
+            'where' => $whereClause,
+            'total_rows' => (int)($row['total_rows'] ?? 0)
+        ]);
+    } catch (Throwable $e) {
+        http_response_code(500);
+        echo json_encode(['status' => 'error', 'error' => $e->getMessage()]);
+    }
     exit;
 }
 

--- a/admin/dashboard.js
+++ b/admin/dashboard.js
@@ -37,6 +37,97 @@ export function renderDashboardLayout(ctx) {
 
     workspaceEl.appendChild(createTextInput('layout_cols', 'Grid Columns (CSS)', currentConfig.layout.columns, v => currentConfig.layout.columns = v));
     workspaceEl.appendChild(createTextInput('layout_gap', 'Grid Gap (CSS)', currentConfig.layout.gap, v => currentConfig.layout.gap = v));
+
+    const statsTitle = document.createElement('h4');
+    statsTitle.textContent = 'Main Table Quick Stats';
+    statsTitle.style.marginTop = '20px';
+    workspaceEl.appendChild(statsTitle);
+
+    const mainTable = Array.isArray(currentConfig.widgets)
+        ? (currentConfig.widgets.find(w => w && w.table)?.table || '')
+        : '';
+
+    const whereInput = createTextInput(
+        'main_table_where',
+        'Main Table WHERE Clause (optional, without WHERE)',
+        currentConfig.main_table_where || '',
+        async v => {
+            currentConfig.main_table_where = v;
+            await refreshMainTableCount();
+        }
+    );
+    workspaceEl.appendChild(whereInput);
+
+    const countCard = document.createElement('div');
+    countCard.style.border = '1px solid #dbe2ea';
+    countCard.style.borderRadius = '8px';
+    countCard.style.padding = '14px';
+    countCard.style.background = '#f8fafc';
+    countCard.style.maxWidth = '360px';
+
+    const countLabel = document.createElement('div');
+    countLabel.style.fontSize = '13px';
+    countLabel.style.color = '#64748b';
+    countLabel.textContent = mainTable
+        ? `Total rows in "${mainTable}"`
+        : 'Total rows in main table';
+
+    const countValue = document.createElement('div');
+    countValue.style.fontSize = '28px';
+    countValue.style.fontWeight = '700';
+    countValue.style.color = '#0f172a';
+    countValue.style.marginTop = '6px';
+    countValue.textContent = '-';
+
+    const countHint = document.createElement('div');
+    countHint.style.fontSize = '12px';
+    countHint.style.color = '#64748b';
+    countHint.style.marginTop = '8px';
+    countHint.textContent = mainTable
+        ? 'Uses first configured widget table as main table.'
+        : 'Configure at least one widget table to see row count.';
+
+    countCard.appendChild(countLabel);
+    countCard.appendChild(countValue);
+    countCard.appendChild(countHint);
+    workspaceEl.appendChild(countCard);
+
+    async function refreshMainTableCount() {
+        if (!mainTable) {
+            countValue.textContent = '-';
+            return;
+        }
+
+        countValue.textContent = '...';
+        try {
+            const params = new URLSearchParams({
+                action: 'dashboard_main_table_count',
+                table: mainTable
+            });
+
+            const whereClause = (currentConfig.main_table_where || '').trim();
+            if (whereClause) {
+                params.set('where', whereClause);
+            }
+
+            const res = await fetch(`api.php?${params.toString()}`);
+            const data = await res.json();
+
+            if (!res.ok || data.status !== 'success') {
+                throw new Error(data.error || 'Failed to fetch row count.');
+            }
+
+            countValue.textContent = String(data.total_rows ?? 0);
+            countHint.textContent = whereClause
+                ? `Filtered by: ${whereClause}`
+                : 'Unfiltered total row count.';
+        } catch (err) {
+            countValue.textContent = '-';
+            countHint.textContent = err.message || 'Failed to fetch row count.';
+        }
+    }
+
+    refreshMainTableCount();
 }
 
 export function renderDashboardEditor(key, itemData, isArray, ctx) {
@@ -63,17 +154,20 @@ export function renderDashboardEditor(key, itemData, isArray, ctx) {
         q.type = q.type || 'count'; q.column = q.column || 'id';
         queryBlock.appendChild(createSelectInput('q_type', 'Aggregation Function', [{value:'count',label:'Count'}, {value:'sum',label:'Sum'}, {value:'avg',label:'Average'}], q.type, v => q.type = v));
         queryBlock.appendChild(createSelectInput('q_col', 'Target Column', colOptions, q.column, v => q.column = v));
+        queryBlock.appendChild(createTextInput('q_where', 'WHERE Clause (optional, without WHERE)', q.where || '', v => q.where = v));
         workspaceEl.appendChild(queryBlock);
     } else if (itemData.type === 'bar_chart') {
         q.type = 'group_by'; 
         queryBlock.appendChild(createSelectInput('q_group', 'Group By Column (X-Axis)', colOptions, q.group_column || '', v => q.group_column = v));
         queryBlock.appendChild(createSelectInput('q_agg_col', 'Aggregation Column (Y-Axis)', colOptions, q.agg_column || 'id', v => q.agg_column = v));
         queryBlock.appendChild(createSelectInput('q_agg_type', 'Aggregation Function', [{value:'count',label:'Count'}, {value:'sum',label:'Sum'}], q.agg_type || 'count', v => q.agg_type = v));
+        queryBlock.appendChild(createTextInput('q_where', 'WHERE Clause (optional, without WHERE)', q.where || '', v => q.where = v));
         workspaceEl.appendChild(queryBlock);
     } else if (itemData.type === 'list') {
         queryBlock.appendChild(createTextInput('q_limit', 'Limit Rows', q.limit || 5, v => q.limit = parseInt(v) || 5));
         queryBlock.appendChild(createSelectInput('q_order', 'Order By Column', colOptions, q.order_by || 'id', v => q.order_by = v));
         queryBlock.appendChild(createSelectInput('q_dir', 'Order Direction', [{value:'DESC',label:'Descending'}, {value:'ASC',label:'Ascending'}], q.dir || 'DESC', v => q.dir = v));
+        queryBlock.appendChild(createTextInput('q_where', 'WHERE Clause (optional, without WHERE)', q.where || '', v => q.where = v));
         workspaceEl.appendChild(queryBlock);
     }
 


### PR DESCRIPTION
This Pull Request implements the new Table Statistics feature for the admin dashboard.

The change adds a small statistics card that shows the total number of rows for the main selected table.
It also introduces support for an optional WHERE clause so users can view filtered totals directly from the dashboard configuration.

**What changed**
Added a new admin API endpoint to return table row count.
Added optional WHERE clause handling for filtered counts.
Added a Table Statistics card in dashboard global settings.
Added UI inputs to define and apply WHERE filters for the count query.

**Why**
This improves dashboard usability by giving quick visibility into table size and filtered dataset totals without leaving the admin panel.

**Manual testing**
Opened admin dashboard settings and confirmed the statistics card is displayed.
Selected a valid table and verified total row count is returned.
Tested endpoint without filter:
total rows returned correctly.
Tested endpoint with filter (example: status = 'active'):
filtered total returned correctly.
Confirmed save flow still works and no regression in dashboard editor behavior.

**Issue**
Closes #22 