### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/vanilla-check.yml
+++ b/.github/workflows/vanilla-check.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   check-for-frameworks:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/wrobeltomasz/open-sparrow/security/code-scanning/3](https://github.com/wrobeltomasz/open-sparrow/security/code-scanning/3)

In general, to fix this type of issue, you add an explicit `permissions:` block to the workflow (either at the top level or per job) that grants only the minimal scopes required. For a workflow that just checks out code and does local scanning, `contents: read` is sufficient; no write permissions are needed.

For this specific file (`.github/workflows/vanilla-check.yml`), the simplest and least intrusive fix is to add a `permissions:` section at the workflow root (between `on:` and `jobs:`) so it applies to all jobs in the workflow. The content should be:

```yaml
permissions:
  contents: read
```

No other functionality changes are needed: `actions/checkout@v4` works fine with `contents: read` and the shell `grep` commands do not interact with GitHub. No imports or additional methods are required because this is a YAML configuration file, not application code.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
