### PR TITLE
Potential fix for code scanning alert no. 6: DOM text reinterpreted as HTML

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -265,7 +265,22 @@ function handleColumnFilterChange() {
     else if (type.includes('bool')) {
         const select = document.createElement('select');
         const displayName = colCfg.display_name || col;
-        select.innerHTML = `<option value="">${displayName}: All</option><option value="true">Yes</option><option value="false">No</option>`;
+
+        const optAll = document.createElement('option');
+        optAll.value = '';
+        optAll.textContent = `${displayName}: All`;
+        select.appendChild(optAll);
+
+        const optTrue = document.createElement('option');
+        optTrue.value = 'true';
+        optTrue.textContent = 'Yes';
+        select.appendChild(optTrue);
+
+        const optFalse = document.createElement('option');
+        optFalse.value = 'false';
+        optFalse.textContent = 'No';
+        select.appendChild(optFalse);
+
         if (existingFilter.val) select.value = existingFilter.val;
         
         select.addEventListener('change', () => { 


### PR DESCRIPTION
Potential fix for [https://github.com/wrobeltomasz/open-sparrow/security/code-scanning/6](https://github.com/wrobeltomasz/open-sparrow/security/code-scanning/6)

In general, the fix is to avoid inserting untrusted text into the DOM via `innerHTML` or other APIs that treat strings as HTML. Instead, construct DOM elements programmatically and set only safe properties like `textContent` or `value`, which do not interpret the text as HTML.

For this specific case, we should stop building the `<select>` options for the boolean filter with a string passed to `select.innerHTML`. Instead, we will create `<option>` elements with `document.createElement('option')`, set their `.value` and `.textContent` properties (using `displayName` only as text), and append them with `appendChild`. This preserves the visual output—“<displayName>: All”, “Yes”, “No”—while ensuring that `displayName` is never parsed as HTML. The only code we need to change is in `assets/js/app.js` within the `else if (type.includes('bool'))` branch, around line 268. No new imports or external methods are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
