### PR TITLE
Add user role support and UI controls

### DIFF
--- a/admin/api.php
+++ b/admin/api.php
@@ -26,7 +26,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 }
 
 // Ensure state-changing actions use POST method to prevent CSRF via GET
-$postActions = ['save', 'import', 'init_db', 'users_add', 'users_toggle', 'create_table', 'add_column'];
+$postActions = ['save', 'import', 'init_db', 'users_add', 'users_toggle', 'users_update_role', 'create_table', 'add_column'];
 if (in_array($action, $postActions, true) && $_SERVER['REQUEST_METHOD'] !== 'POST') {
     header('Content-Type: application/json');
     http_response_code(405);
@@ -41,7 +41,7 @@ if ($action === 'init_db') {
         $conn = db_connect();
         $queries = [
             "CREATE SCHEMA IF NOT EXISTS app",
-            "CREATE TABLE IF NOT EXISTS app.users ( id serial4 NOT NULL, username varchar(50) NOT NULL, password_hash varchar(255) NOT NULL, is_active bool DEFAULT true, CONSTRAINT users_pkey PRIMARY KEY (id), CONSTRAINT users_username_key UNIQUE (username) )",
+            "CREATE TABLE IF NOT EXISTS app.users ( id serial4 NOT NULL, username varchar(50) NOT NULL, password_hash varchar(255) NOT NULL, is_active bool DEFAULT true, role varchar(20) DEFAULT 'full' NOT NULL, CONSTRAINT users_pkey PRIMARY KEY (id), CONSTRAINT users_username_key UNIQUE (username) )",
             "ALTER TABLE app.users ADD COLUMN IF NOT EXISTS is_active bool DEFAULT true",
             "CREATE TABLE IF NOT EXISTS app.users_log ( id serial4 NOT NULL, user_id int4 NOT NULL, \"action\" varchar(50) NOT NULL, target_table varchar(100), record_id int4, created_at timestamp DEFAULT CURRENT_TIMESTAMP, CONSTRAINT users_log_pkey PRIMARY KEY (id) )",
             "CREATE TABLE IF NOT EXISTS app.users_notifications ( id serial4 NOT NULL, user_id int8 NOT NULL, title varchar(255) NOT NULL, link varchar(255), source_table varchar(100), source_id int8, is_read bool DEFAULT false, notify_date date NOT NULL, created_at timestamp DEFAULT CURRENT_TIMESTAMP,CONSTRAINT users_notifications_pkey PRIMARY KEY (id), CONSTRAINT users_notifications_user_id_source_table_source_id_notify_d_key UNIQUE (user_id, source_table, source_id, notify_date) )",
@@ -69,7 +69,7 @@ if ($action === 'users_list') {
     try {
         require_once __DIR__ . '/../includes/db.php';
         $conn = db_connect();
-        $sql = "SELECT id, username, is_active FROM app.users ORDER BY id ASC";
+        $sql = "SELECT id, username, is_active, role FROM app.users ORDER BY id ASC";
         $res = @pg_query($conn, $sql);
         if (!$res) {
             $err = pg_last_error($conn);
@@ -103,6 +103,8 @@ if ($action === 'users_add') {
     $data = json_decode(file_get_contents('php://input'), true);
     $username = trim($data['username'] ?? '');
     $password = $data['password'] ?? '';
+    $role = isset($data['role']) && $data['role'] === 'readonly' ? 'readonly' : 'full';
+    
     if (empty($username) || empty($password)) {
         echo json_encode(['status' => 'error', 'error' => 'Username and password are required.']);
         exit;
@@ -112,8 +114,8 @@ if ($action === 'users_add') {
         require_once __DIR__ . '/../includes/db.php';
         $conn = db_connect();
         $hash = password_hash($password, PASSWORD_DEFAULT);
-        $sql = "INSERT INTO app.users (username, password_hash, is_active) VALUES ($1, $2, true)";
-        $res = @pg_query_params($conn, $sql, [$username, $hash]);
+        $sql = "INSERT INTO app.users (username, password_hash, is_active, role) VALUES ($1, $2, true, $3)";
+        $res = @pg_query_params($conn, $sql, [$username, $hash, $role]);
         if (!$res) {
             throw new Exception(pg_last_error($conn));
         }
@@ -145,6 +147,38 @@ if ($action === 'users_toggle') {
         $conn = db_connect();
         $sql = "UPDATE app.users SET is_active = $1 WHERE id = $2";
         $res = @pg_query_params($conn, $sql, [$isActive ? 'true' : 'false', $userId]);
+        if (!$res) {
+            throw new Exception(pg_last_error($conn));
+        }
+        echo json_encode(['status' => 'success']);
+    } catch (Exception $e) {
+        echo json_encode(['status' => 'error', 'error' => $e->getMessage()]);
+    }
+    exit;
+}
+
+// Handle user role update
+if ($action === 'users_update_role') {
+    header('Content-Type: application/json');
+    if ($isDemoMode) {
+        echo json_encode(['status' => 'error', 'error' => 'Action disabled in Demo Mode.']);
+        exit;
+    }
+
+    $data = json_decode(file_get_contents('php://input'), true);
+    $userId = (int)($data['id'] ?? 0);
+    $role = isset($data['role']) && $data['role'] === 'readonly' ? 'readonly' : 'full';
+
+    if ($userId <= 0) {
+        echo json_encode(['status' => 'error', 'error' => 'Invalid user ID.']);
+        exit;
+    }
+
+    try {
+        require_once __DIR__ . '/../includes/db.php';
+        $conn = db_connect();
+        $sql = "UPDATE app.users SET role = $1 WHERE id = $2";
+        $res = @pg_query_params($conn, $sql, [$role, $userId]);
         if (!$res) {
             throw new Exception(pg_last_error($conn));
         }
@@ -317,7 +351,7 @@ if ($action === 'import' && isset($_FILES['backup_file'])) {
         // Validate each file inside the archive
         for ($i = 0; $i < $zip->numFiles; $i++) {
             $filename = $zip->getNameIndex($i);
-// Block path traversal characters and enforce .json extension to prevent RCE
+            // Block path traversal characters and enforce .json extension to prevent RCE
             if (str_contains($filename, '../') || str_contains($filename, '..\\') || substr($filename, -5) !== '.json') {
                 $zip->close();
                 http_response_code(400);
@@ -378,7 +412,7 @@ if ($action === 'get' && in_array($file, $allowedFiles, true)) {
     header('Content-Type: application/json');
     if (file_exists($filePath)) {
         $fileContent = file_get_contents($filePath);
-    // Mask sensitive data in Demo Mode
+        // Mask sensitive data in Demo Mode
         if ($isDemoMode && $file === 'database') {
             $dbData = json_decode($fileContent, true);
             $dbData['host'] = 'hidden-for-demo.postgres.database.azure.com';
@@ -403,7 +437,7 @@ if ($action === 'get' && in_array($file, $allowedFiles, true)) {
 
 // Save content to a JSON config file
 if ($action === 'save' && in_array($file, $allowedFiles, true)) {
-// Block saving sensitive files in Demo Mode
+    // Block saving sensitive files in Demo Mode
     if ($isDemoMode && in_array($file, ['database', 'security'])) {
         http_response_code(403);
         echo json_encode(['status' => 'error', 'error' => 'Saving ' . $file . ' configuration is disabled in Demo Mode.']);
@@ -415,7 +449,7 @@ if ($action === 'save' && in_array($file, $allowedFiles, true)) {
     header('Content-Type: application/json');
     $parsedData = json_decode($data, true);
     if ($parsedData !== null) {
-    // Hash the admin password securely before saving if it is not hashed already
+        // Hash the admin password securely before saving if it is not hashed already
         if ($file === 'security' && !empty($parsedData['admin_password'])) {
             $info = password_get_info($parsedData['admin_password']);
             if ($info['algoName'] === 'unknown') {
@@ -479,7 +513,7 @@ if ($action === 'get_db_columns') {
             $dataType = $row['data_type'];
             $udtName = $row['udt_name'];
             $enumValues = null;
-        // Fetch ENUM values only for user-defined types safely using pg_escape_identifier
+            // Fetch ENUM values only for user-defined types safely using pg_escape_identifier
             if ($dataType === 'USER-DEFINED') {
                 $safeSchema = pg_escape_identifier($conn, $schemaName);
                 $safeUdt = pg_escape_identifier($conn, $udtName);

--- a/admin/users.js
+++ b/admin/users.js
@@ -30,6 +30,7 @@ export async function renderUsersEditor(ctx) {
                         <th style="padding: 10px;">ID</th>
                         <th style="padding: 10px;">Username</th>
                         <th style="padding: 10px;">Status</th>
+                        <th style="padding: 10px;">FE Permission</th>
                         <th style="padding: 10px;">Actions</th>
                     </tr>
                 </thead>
@@ -45,6 +46,12 @@ export async function renderUsersEditor(ctx) {
                         <span style="padding: 4px 8px; border-radius: 4px; font-size: 12px; color: white; background: ${u.is_active ? '#10b981' : '#ef4444'};">
                             ${u.is_active ? 'Active' : 'Inactive'}
                         </span>
+                    </td>
+                    <td style="padding: 10px;">
+                        <select class="select-user-role" data-id="${u.id}" style="padding: 5px; border-radius: 4px; border: 1px solid #cbd5e1; background: #fff;">
+                            <option value="full" ${u.role === 'full' || !u.role ? 'selected' : ''}>Full Access</option>
+                            <option value="readonly" ${u.role === 'readonly' ? 'selected' : ''}>Read Only</option>
+                        </select>
                     </td>
                     <td style="padding: 10px;">
                         <button class="btn-toggle-user" data-id="${u.id}" data-active="${u.is_active}" style="padding: 5px 10px; cursor: pointer; border: none; border-radius: 4px; background: ${u.is_active ? '#f59e0b' : '#3b82f6'}; color: white; font-weight: bold;">
@@ -73,13 +80,20 @@ export async function renderUsersEditor(ctx) {
                     </div>
                     <small id="passwordStrengthLabel" style="color: #777; display: block; margin-top: 4px;"></small>
                 </div>
+                <div style="margin-bottom: 15px;">
+                    <label style="display: block; font-weight: bold; margin-bottom: 5px;">FE Permission</label>
+                    <select id="newRole" style="width: 100%; padding: 8px; border: 1px solid #ccc; border-radius: 4px; box-sizing: border-box;">
+                        <option value="full">Full Access</option>
+                        <option value="readonly">Read Only</option>
+                    </select>
+                </div>
                 <button id="btnAddUser" style="background: #10b981; color: white; border: none; padding: 10px 15px; border-radius: 4px; cursor: pointer; font-weight: bold;">Create User</button>
             </div>
         `;
         
         workspaceEl.innerHTML = html;
         
-        // Setup toggle events
+        // Setup toggle active status events
         workspaceEl.querySelectorAll('.btn-toggle-user').forEach(btn => {
             btn.addEventListener('click', async (e) => {
                 const id = e.target.getAttribute('data-id');
@@ -104,6 +118,34 @@ export async function renderUsersEditor(ctx) {
                     }
                 } catch (err) {
                     alert('Network error occurred.');
+                }
+            });
+        });
+
+        // Setup role change events
+        workspaceEl.querySelectorAll('.select-user-role').forEach(select => {
+            select.addEventListener('change', async (e) => {
+                const id = e.target.getAttribute('data-id');
+                const role = e.target.value;
+                
+                try {
+                    const req = await fetch('api.php?action=users_update_role', {
+                        method: 'POST',
+                        headers: { 
+                            'Content-Type': 'application/json',
+                            'X-CSRF-Token': getCsrfToken() 
+                        },
+                        body: JSON.stringify({ id, role })
+                    });
+                    
+                    const resData = await req.json();
+                    if (resData.status !== 'success') {
+                        alert('Error: ' + resData.error);
+                        renderUsersEditor(ctx); 
+                    }
+                } catch (err) {
+                    alert('Network error occurred.');
+                    renderUsersEditor(ctx); 
                 }
             });
         });
@@ -147,6 +189,7 @@ export async function renderUsersEditor(ctx) {
         document.getElementById('btnAddUser').addEventListener('click', async () => {
             const username = document.getElementById('newUsername').value;
             const password = document.getElementById('newPassword').value;
+            const role = document.getElementById('newRole').value;
 
             if (!username || !password) {
                 alert('Username and password are required!');
@@ -160,7 +203,7 @@ export async function renderUsersEditor(ctx) {
                         'Content-Type': 'application/json',
                         'X-CSRF-Token': getCsrfToken() 
                     },
-                    body: JSON.stringify({ username, password })
+                    body: JSON.stringify({ username, password, role })
                 });
                 const resData = await req.json();
 


### PR DESCRIPTION
Introduce front-end permission (role) support for users. Add a new role column (varchar, default 'full') to app.users and include role in users_list queries. Extend users_add to accept and store a role, and add a new users_update_role POST endpoint (with Demo Mode protection) to update roles server-side. Update POST-protected actions list to require POST for users_update_role. On the frontend, add a FE Permission column, per-user role select, and a new role selector when creating users; send role in create requests and POST role updates to the new API action (including CSRF token). Also include a few minor whitespace/comment tweaks in api.php.

## Description
Describe your changes here. What problem does this PR solve?

## Related Issue
Fixes #34 

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have tested these changes manually
- [ ] (Optional) I have updated the documentation