### PR TITLE
Add readonly user role enforcement

### DIFF
--- a/api.php
+++ b/api.php
@@ -1,15 +1,21 @@
 <?php
-
 declare(strict_types=1);
 
-if (session_status() === PHP_SESSION_NONE) {
-    session_start();
-}
+session_start();
 
+// Block access without active session
 if (!isset($_SESSION['user_id'])) {
     http_response_code(401);
-    echo json_encode(['error' => 'Unauthorized']);
-    exit;
+    exit(json_encode(['error' => 'Unauthorized']));
+}
+
+$method = $_SERVER['REQUEST_METHOD'];
+$role = $_SESSION['role'] ?? 'full';
+
+// Block data modification requests for readonly users
+if ($role === 'readonly' && in_array($method, ['POST', 'PUT', 'PATCH', 'DELETE'], true)) {
+    http_response_code(403);
+    exit(json_encode(['error' => 'Forbidden: Read-only access']));
 }
 
 // Load schema

--- a/assets/js/grid.js
+++ b/assets/js/grid.js
@@ -3,6 +3,10 @@ import { onCellBlur, onInputChange, deleteRow, addRow, attachCellEvents } from '
 import { setupPagination, getPageRows } from './pagination.js';
 import { exportCSV } from './export_csv.js';
 
+// Retrieve global user role
+const userRole = window.USER_ROLE || 'full';
+const isReadOnly = userRole === 'readonly';
+
 const fkCache = {};
 
 let currentTable = null;
@@ -116,14 +120,20 @@ export async function loadTable(schema, table, gridTitleEl, addRowBtn) {
 
         filteredData = fullData.slice();
         unsortedFilteredData = filteredData.slice(); 
-        addRowBtn.disabled = false;
         sortState = { column: null, asc: true };
 
-        // Redirect to create form on button click
-        addRowBtn.onclick = () => {
-            debugLog("Redirect to create form", { table: currentTable });
-            window.location.href = `create.php?table=${currentTable}`;
-        };
+        // Handle add row button visibility based on user role
+        if (isReadOnly) {
+            addRowBtn.style.display = 'none';
+        } else {
+            addRowBtn.style.display = '';
+            addRowBtn.disabled = false;
+            // Redirect to create form on button click
+            addRowBtn.onclick = () => {
+                debugLog("Redirect to create form", { table: currentTable });
+                window.location.href = `create.php?table=${currentTable}`;
+            };
+        }
 
         await renderGrid(schema);
 
@@ -298,9 +308,13 @@ export async function renderGrid(schema) {
         headRow.appendChild(th);
     });
 
-    const thActions = document.createElement('th');
-    thActions.textContent = 'Actions';
-    headRow.appendChild(thActions);
+    // Render Actions header only for full permission users
+    if (!isReadOnly) {
+        const thActions = document.createElement('th');
+        thActions.textContent = 'Actions';
+        headRow.appendChild(thActions);
+    }
+    
     thead.appendChild(headRow);
     table.appendChild(thead);
 
@@ -327,7 +341,7 @@ export async function renderGrid(schema) {
                     const ddTr = document.createElement('tr');
                     ddTr.className = 'drilldown-row';
                     const ddTd = document.createElement('td');
-                    ddTd.colSpan = displayedColumns.length + 2; 
+                    ddTd.colSpan = displayedColumns.length + (isReadOnly ? 1 : 2); 
                     ddTd.innerHTML = '<em>Loading...</em>';
                     ddTr.appendChild(ddTd);
                     tr.after(ddTr);
@@ -419,7 +433,7 @@ export async function renderGrid(schema) {
                 input.dataset.column = col;
                 input.dataset.id = row['id'];
 
-                if (colCfg.readonly) {
+                if (colCfg.readonly || isReadOnly) {
                     input.disabled = true;
                 }
 
@@ -471,7 +485,7 @@ export async function renderGrid(schema) {
                     }
                 });
 
-                attachCellEvents(input);
+                if (!isReadOnly) attachCellEvents(input);
                 td.appendChild(input);
                 td.appendChild(datalist);
                 tr.appendChild(td);
@@ -516,7 +530,7 @@ export async function renderGrid(schema) {
 
                 applyEnumColor(value);
 
-                if (colCfg.readonly) {
+                if (colCfg.readonly || isReadOnly) {
                     select.disabled = true;
                 }
 
@@ -524,7 +538,7 @@ export async function renderGrid(schema) {
                     applyEnumColor(e.target.value);
                 });
 
-                attachCellEvents(select);
+                if (!isReadOnly) attachCellEvents(select);
                 td.appendChild(select);
             }
             // Render boolean as checkbox
@@ -535,11 +549,11 @@ export async function renderGrid(schema) {
                 input.dataset.column = col;
                 input.dataset.id = row['id'];
 
-                if (colCfg.readonly) {
+                if (colCfg.readonly || isReadOnly) {
                     input.disabled = true;
                 }
 
-                attachCellEvents(input);
+                if (!isReadOnly) attachCellEvents(input);
                 td.appendChild(input);
             }
             // Render date picker
@@ -550,16 +564,16 @@ export async function renderGrid(schema) {
                 input.dataset.column = col;
                 input.dataset.id = row['id'];
 
-                if (colCfg.readonly) {
+                if (colCfg.readonly || isReadOnly) {
                     input.disabled = true;
                 }
 
-                attachCellEvents(input);
+                if (!isReadOnly) attachCellEvents(input);
                 td.appendChild(input);
             }
             // Render editable text cell
             else {
-                if (!colCfg.readonly) {
+                if (!colCfg.readonly && !isReadOnly) {
                     td.contentEditable = 'true';
                     td.classList.add('editable');
                 }
@@ -610,7 +624,7 @@ export async function renderGrid(schema) {
                     td.textContent = value;
                 }
 
-                attachCellEvents(td);
+                if (!isReadOnly) attachCellEvents(td);
 
                 td.addEventListener('keydown', e => {
                     if (e.key === 'Enter') {
@@ -629,36 +643,39 @@ export async function renderGrid(schema) {
             tr.appendChild(td);
         }
 
-        const tdActions = document.createElement('td');
-        
-        // Edit action button
-        const editBtn = document.createElement('button');
-        editBtn.textContent = 'Edit';
-        editBtn.style.marginRight = '8px';
-        editBtn.addEventListener('click', () => {
-            window.location.href = `edit.php?table=${currentTable}&id=${row['id']}`;
-        });
-        tdActions.appendChild(editBtn);
+        // Render action buttons only if user is not readonly
+        if (!isReadOnly) {
+            const tdActions = document.createElement('td');
+            
+            // Edit action button
+            const editBtn = document.createElement('button');
+            editBtn.textContent = 'Edit';
+            editBtn.style.marginRight = '8px';
+            editBtn.addEventListener('click', () => {
+                window.location.href = `edit.php?table=${currentTable}&id=${row['id']}`;
+            });
+            tdActions.appendChild(editBtn);
 
-        // Delete action button
-        const delBtn = document.createElement('button');
-        delBtn.textContent = 'Delete';
-        delBtn.className = 'danger';
+            // Delete action button
+            const delBtn = document.createElement('button');
+            delBtn.textContent = 'Delete';
+            delBtn.className = 'danger';
 
-        delBtn.addEventListener('click', async () => {
-            if (confirm("Are you sure you want to delete this record? This operation cannot be undone.")) {
-                const result = await deleteRow(row['id']);
-                if (result?.ok) {
-                    fullData = fullData.filter(r => String(r.id) !== String(row['id']));
-                    filteredData = filteredData.filter(r => String(r.id) !== String(row['id']));
-                    unsortedFilteredData = unsortedFilteredData.filter(r => String(r.id) !== String(row['id']));
-                    renderGrid(schema);
+            delBtn.addEventListener('click', async () => {
+                if (confirm("Are you sure you want to delete this record? This operation cannot be undone.")) {
+                    const result = await deleteRow(row['id']);
+                    if (result?.ok) {
+                        fullData = fullData.filter(r => String(r.id) !== String(row['id']));
+                        filteredData = filteredData.filter(r => String(r.id) !== String(row['id']));
+                        unsortedFilteredData = unsortedFilteredData.filter(r => String(r.id) !== String(row['id']));
+                        renderGrid(schema);
+                    }
                 }
-            }
-        });
+            });
 
-        tdActions.appendChild(delBtn);
-        tr.appendChild(tdActions);
+            tdActions.appendChild(delBtn);
+            tr.appendChild(tdActions);
+        }
 
         tbody.appendChild(tr);
     }

--- a/create.php
+++ b/create.php
@@ -5,6 +5,13 @@ if (!isset($_SESSION['user_id'])) {
     exit;
 }
 
+// Check role and block POST requests for readonly users
+$isReadOnly = ($_SESSION['role'] ?? 'full') === 'readonly';
+if ($isReadOnly && $_SERVER['REQUEST_METHOD'] === 'POST') {
+    http_response_code(403);
+    die("Forbidden: Read-only access");
+}
+
 require __DIR__ . '/includes/db.php';
 require __DIR__ . '/includes/api_helpers.php';
 $conn = db_connect();
@@ -136,7 +143,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 $prefillVal = $_GET[$colName] ?? '';
 
                 $requiredAttr = !empty($colCfg['not_null']) ? 'required' : '';
-                $disabledAttr = $isPrefilled ? 'disabled' : '';
+                // Disable field if prefilled or user is readonly
+                $disabledAttr = ($isPrefilled || $isReadOnly) ? 'disabled' : '';
                 $nameAttr = $isPrefilled ? '' : 'name="' . $colName . '"';
                 ?>
                 <div class="form-group" style="margin-bottom: 15px;">
@@ -220,7 +228,11 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             <?php endforeach; ?>
 
             <div class="form-actions" style="margin-top: 25px; display: flex; gap: 10px;">
-                <button type="submit" class="btn-save" style="padding: 10px 20px; background: #007ACC; color: white; border: none; cursor: pointer; font-weight: bold; border-radius: 4px;">Add Record</button>
+                <?php if ($isReadOnly) : ?>
+                    <button type="button" class="btn-save" style="padding: 10px 20px; background: #ccc; color: white; border: none; cursor: not-allowed; font-weight: bold; border-radius: 4px;" disabled>Add Record</button>
+                <?php else : ?>
+                    <button type="submit" class="btn-save" style="padding: 10px 20px; background: #007ACC; color: white; border: none; cursor: pointer; font-weight: bold; border-radius: 4px;">Add Record</button>
+                <?php endif; ?>
                 <button type="button" class="btn-cancel" onclick="window.history.back()" style="padding: 10px 20px; background: #eee; color: #333; border: 1px solid #ccc; cursor: pointer; border-radius: 4px;">Cancel</button>
             </div>
         </form>

--- a/edit.php
+++ b/edit.php
@@ -5,6 +5,14 @@ if (!isset($_SESSION['user_id'])) {
     exit;
 }
 
+$isReadOnly = ($_SESSION['role'] ?? 'full') === 'readonly';
+
+// Block POST request for readonly users
+if ($isReadOnly && $_SERVER['REQUEST_METHOD'] === 'POST') {
+    http_response_code(403);
+    die("Forbidden: Read-only access");
+}
+
 require __DIR__ . '/includes/db.php';
 require __DIR__ . '/includes/api_helpers.php';
 $conn = db_connect();
@@ -169,9 +177,10 @@ if (!empty($tableCfg['subtables']) && is_array($tableCfg['subtables'])) {
                 $type = strtolower($colCfg['type'] ?? '');
                 $val = $row[$colName] ?? '';
 
-                $readOnlyAttr = !empty($colCfg['readonly']) ? 'readonly' : '';
-                $disabledAttr = !empty($colCfg['readonly']) ? 'disabled' : '';
-                $requiredAttr = (!empty($colCfg['not_null']) && empty($colCfg['readonly'])) ? 'required' : '';
+                // Apply read-only mode across all fields if user role is readonly
+                $readOnlyAttr = (!empty($colCfg['readonly']) || $isReadOnly) ? 'readonly' : '';
+                $disabledAttr = (!empty($colCfg['readonly']) || $isReadOnly) ? 'disabled' : '';
+                $requiredAttr = (!empty($colCfg['not_null']) && empty($colCfg['readonly']) && !$isReadOnly) ? 'required' : '';
                 ?>
                 <div class="form-group" style="margin-bottom: 15px;">
                     <label style="display: block; font-weight: bold; margin-bottom: 5px;">
@@ -216,7 +225,7 @@ if (!empty($tableCfg['subtables']) && is_array($tableCfg['subtables'])) {
                                 </option>
                             <?php endwhile; ?>
                         </select>
-                        <?php if (!empty($colCfg['readonly'])) : ?>
+                        <?php if (!empty($colCfg['readonly']) || $isReadOnly) : ?>
                             <input type="hidden" name="<?php echo $colName; ?>" value="<?php echo htmlspecialchars((string)$val); ?>" />
                         <?php endif; ?>
 
@@ -232,14 +241,14 @@ if (!empty($tableCfg['subtables']) && is_array($tableCfg['subtables'])) {
                                 <?php endforeach; ?>
                             <?php endif; ?>
                         </select>
-                        <?php if (!empty($colCfg['readonly'])) : ?>
+                        <?php if (!empty($colCfg['readonly']) || $isReadOnly) : ?>
                             <input type="hidden" name="<?php echo $colName; ?>" value="<?php echo htmlspecialchars((string)$val); ?>" />
                         <?php endif; ?>
 
                     <?php elseif (str_contains($type, 'bool')) : ?>
                         <?php $checked = ($val === 't' || $val === 'true' || $val === true || $val === '1') ? 'checked' : ''; ?>
                         <input type="checkbox" name="<?php echo $colName; ?>" <?php echo $disabledAttr; ?> <?php echo $checked; ?> />
-                        <?php if (!empty($colCfg['readonly'])) : ?>
+                        <?php if (!empty($colCfg['readonly']) || $isReadOnly) : ?>
                             <input type="hidden" name="<?php echo $colName; ?>" value="<?php echo htmlspecialchars((string)$val); ?>" />
                         <?php endif; ?>
                         
@@ -258,7 +267,11 @@ if (!empty($tableCfg['subtables']) && is_array($tableCfg['subtables'])) {
             <?php endforeach; ?>
 
             <div class="form-actions" style="margin-top: 20px;">
-                <button type="submit" class="btn-save">Save Changes</button>
+                <?php if ($isReadOnly) : ?>
+                    <button type="button" class="btn-save" style="background: #ccc; cursor: not-allowed;" disabled>Update Record</button>
+                <?php else : ?>
+                    <button type="submit" class="btn-save">Save Changes</button>
+                <?php endif; ?>
                 <button type="button" class="btn-cancel" onclick="window.history.back()">Cancel</button>
             </div>
         </form>
@@ -274,9 +287,11 @@ if (!empty($tableCfg['subtables']) && is_array($tableCfg['subtables'])) {
             ?>
             <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 10px;">
                 <h3><?php echo htmlspecialchars($sLabel); ?></h3>
-                <a href="create.php?table=<?php echo urlencode($sTable); ?>&<?php echo urlencode($sFk); ?>=<?php echo urlencode((string)$id); ?>" class="btn-add">
-                    + Add <?php echo htmlspecialchars($sLabel); ?>
-                </a>
+                <?php if (!$isReadOnly) : ?>
+                    <a href="create.php?table=<?php echo urlencode($sTable); ?>&<?php echo urlencode($sFk); ?>=<?php echo urlencode((string)$id); ?>" class="btn-add">
+                        + Add <?php echo htmlspecialchars($sLabel); ?>
+                    </a>
+                <?php endif; ?>
             </div>
 
             <?php if (empty($sd['rows'])) : ?>
@@ -300,7 +315,11 @@ if (!empty($tableCfg['subtables']) && is_array($tableCfg['subtables'])) {
                                         <td><?php echo htmlspecialchars((string)$displayVal); ?></td>
                                     <?php endforeach; ?>
                                     <td class="subtable-actions">
-                                        <a href="edit.php?table=<?php echo urlencode($sTable); ?>&id=<?php echo urlencode($r['id']); ?>" class="btn-action">Edit</a>
+                                        <?php if ($isReadOnly) : ?>
+                                            <a href="edit.php?table=<?php echo urlencode($sTable); ?>&id=<?php echo urlencode($r['id']); ?>" class="btn-action" style="pointer-events: none; opacity: 0.5;">View</a>
+                                        <?php else : ?>
+                                            <a href="edit.php?table=<?php echo urlencode($sTable); ?>&id=<?php echo urlencode($r['id']); ?>" class="btn-action">Edit</a>
+                                        <?php endif; ?>
                                     </td>
                                 </tr>
                             <?php endforeach; ?>

--- a/login.php
+++ b/login.php
@@ -35,7 +35,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && empty($error)) {
     $username = $_POST['username'] ?? '';
     $password = $_POST['password'] ?? '';
 
-    $sql = 'SELECT id, username, password_hash FROM "app"."users" WHERE username = $1';
+    // Fetch role from the database
+    $sql = 'SELECT id, username, password_hash, role FROM "app"."users" WHERE username = $1';
     $res = pg_query_params($conn, $sql, [$username]);
 
     if (!$res) {
@@ -53,6 +54,10 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && empty($error)) {
 
             $_SESSION['user_id'] = $user['id'];
             $_SESSION['username'] = $user['username'];
+            
+            // Assign user role to session
+            $_SESSION['role'] = $user['role'] ?? 'full';
+
             // Log login action
             log_user_action($conn, $user['id'], 'LOGIN');
 


### PR DESCRIPTION
Implement read-only role enforcement across backend and frontend. api.php: start session unconditionally, return 401 for unauthenticated requests, store request method and session role, and block modifying HTTP methods (POST/PUT/PATCH/DELETE) for users with role 'readonly'. assets/js/grid.js: read global USER_ROLE, hide/disable add/edit/delete/actions and disable editable cells for readonly users; conditionally render Actions column and adjust colspan. create.php & edit.php: detect readonly role, block POST submissions for readonly users, disable or hide form controls and submit buttons, add readonly handling for hidden fields and subtable add links, and show view-only links/styles where appropriate. login.php: fetch user role from DB and store in session on successful login. These changes enable a consistent read-only mode for users without modifying core schema.

## Description
Describe your changes here. What problem does this PR solve?

## Related Issue
Fixes #34

## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have tested these changes manually
- [ ] (Optional) I have updated the documentation