### PR TITLE
Add secure schema & FK APIs; harden frontend

### DIFF
--- a/api_fk.php
+++ b/api_fk.php
@@ -1,0 +1,61 @@
+<?php
+// Disable HTML error output to prevent corrupting JSON payload
+ini_set('display_errors', 0);
+
+// Safely start session only if not already active
+if (session_status() === PHP_SESSION_NONE) {
+    session_start();
+}
+
+// Require authorization and AJAX request
+if (!isset($_SESSION['user_id']) || !isset($_SERVER['HTTP_X_REQUESTED_WITH']) || strtolower($_SERVER['HTTP_X_REQUESTED_WITH']) !== 'xmlhttprequest') {
+    http_response_code(403);
+    header('Content-Type: application/json');
+    echo json_encode(['error' => 'Unauthorized']);
+    exit;
+}
+
+$table = $_GET['table'] ?? '';
+$col = $_GET['col'] ?? '';
+
+$schemaPath = __DIR__ . '/includes/schema.json';
+
+// Check if schema file exists
+if (!file_exists($schemaPath)) {
+    header('Content-Type: application/json');
+    echo json_encode(['rows' => []]);
+    exit;
+}
+
+// Read schema file securely
+$raw = file_get_contents($schemaPath);
+if ($raw === false) {
+    header('Content-Type: application/json');
+    echo json_encode(['rows' => []]);
+    exit;
+}
+
+$schemaData = json_decode($raw, true);
+
+// Verify valid schema structure and check if relation exists
+if (!is_array($schemaData) || !isset($schemaData['tables'][$table]['foreign_keys'][$col])) {
+    header('Content-Type: application/json');
+    echo json_encode(['rows' => []]);
+    exit;
+}
+
+$refTable = $schemaData['tables'][$table]['foreign_keys'][$col]['reference_table'] ?? '';
+
+if (empty($refTable)) {
+    header('Content-Type: application/json');
+    echo json_encode(['rows' => []]);
+    exit;
+}
+
+// Rewrite GET parameters to simulate a direct call to api.php for the reference table
+$_GET['api'] = 'list';
+$_GET['table'] = $refTable;
+
+// Delegate response generation to main API handler
+require __DIR__ . '/api.php';
+exit;

--- a/api_schema.php
+++ b/api_schema.php
@@ -1,0 +1,114 @@
+<?php
+// Disable HTML error output to prevent corrupting JSON payload
+ini_set('display_errors', 0);
+
+// Safely start session only if not already active
+if (session_status() === PHP_SESSION_NONE) {
+    session_start();
+}
+
+// Deny access if unauthorized
+if (!isset($_SESSION['user_id'])) {
+    http_response_code(401);
+    echo json_encode(['error' => 'Unauthorized']);
+    exit;
+}
+
+// Ensure response is JSON and prevent caching
+header('Content-Type: application/json');
+header('Cache-Control: no-store, no-cache, must-revalidate');
+
+// Restrict to GET method
+if ($_SERVER['REQUEST_METHOD'] !== 'GET') {
+    http_response_code(405);
+    exit;
+}
+
+// Enforce AJAX request
+if (!isset($_SERVER['HTTP_X_REQUESTED_WITH']) || strtolower($_SERVER['HTTP_X_REQUESTED_WITH']) !== 'xmlhttprequest') {
+    http_response_code(403);
+    exit;
+}
+
+$userRole = $_SESSION['role'] ?? 'readonly';
+$schemaPath = __DIR__ . '/includes/schema.json';
+
+if (!file_exists($schemaPath)) {
+    http_response_code(500);
+    exit;
+}
+
+// Read and validate schema JSON strictly
+$raw = file_get_contents($schemaPath);
+if ($raw === false) {
+    http_response_code(500);
+    echo json_encode(['error' => 'Cannot read schema file']);
+    exit;
+}
+
+$schemaData = json_decode($raw, true);
+if (!is_array($schemaData) || !isset($schemaData['tables'])) {
+    http_response_code(500);
+    echo json_encode(['error' => 'Invalid schema format']);
+    exit;
+}
+
+$publicSchema = [];
+
+foreach ($schemaData['tables'] as $tableName => $tableConfig) {
+    // Skip hidden tables completely
+    if (!empty($tableConfig['hidden'])) continue;
+
+    $publicColumns = [];
+    foreach ($tableConfig['columns'] as $colName => $colDef) {
+        // Build minimal column object
+        $pub = [
+            'display_name'  => $colDef['display_name'] ?? $colName,
+            'type'          => $colDef['type'] ?? 'text',
+            'show_in_grid'  => $colDef['show_in_grid'] ?? true,
+            'show_in_edit'  => $colDef['show_in_edit'] ?? true,
+            'readonly'      => $colDef['readonly'] ?? false,
+            'not_null'      => $colDef['not_null'] ?? false,
+        ];
+
+        // Send validation rules only to users with full access
+        if ($userRole === 'full') {
+            if (!empty($colDef['validation_regexp'])) {
+                $pub['validation_regexp'] = $colDef['validation_regexp'];
+            }
+            if (!empty($colDef['validation_message'])) {
+                $pub['validation_message'] = $colDef['validation_message'];
+            }
+        }
+
+        // Keep dropdown options for UI
+        if (!empty($colDef['options'])) {
+            $pub['options'] = $colDef['options'];
+        }
+        if (!empty($colDef['enum_colors'])) {
+            $pub['enum_colors'] = $colDef['enum_colors'];
+        }
+
+        $publicColumns[$colName] = $pub;
+    }
+
+    // Filter foreign keys
+    $foreignKeys = [];
+    if (!empty($tableConfig['foreign_keys'])) {
+        foreach ($tableConfig['foreign_keys'] as $col => $fk) {
+            $foreignKeys[$col] = [
+                'display_column' => $fk['display_column'] ?? 'id'
+            ];
+        }
+    }
+
+    $publicSchema[$tableName] = [
+        'display_name' => $tableConfig['display_name'] ?? $tableName,
+        'columns'      => $publicColumns,
+        'icon'         => $tableConfig['icon'] ?? null,
+        'foreign_keys' => $foreignKeys,
+        'subtables'    => $tableConfig['subtables'] ?? [],
+    ];
+}
+
+echo json_encode(['tables' => $publicSchema]);

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -35,91 +35,109 @@ function renderIconElement(iconVal, fallbackPath) {
 
 // Initialize application on DOM load
 document.addEventListener('DOMContentLoaded', async () => {
-    if (typeof schema !== 'undefined' && Object.keys(schema.tables).length > 0) {
+    try {
+        // Fetch secure schema dynamically via API instead of reading from HTML
+        const schemaRes = await fetch('api_schema.php', {
+            headers: { 'X-Requested-With': 'XMLHttpRequest' }
+        });
         
-        // Read URL params to check if dashboard redirected us to a specific table
-        const urlParams = new URLSearchParams(window.location.search);
-        const urlTable = urlParams.get('table');
+        if (!schemaRes.ok) throw new Error('Failed to load secure schema');
         
-        // Determine the initial table to load
-        let initialTableName = Object.keys(schema.tables)[0];
-        if (urlTable && schema.tables[urlTable]) {
-            initialTableName = urlTable;
-        }
+        const schemaData = await schemaRes.json();
+        
+        // Define globally so other functions and modules can access it
+        window.schema = schemaData;
+        window.AppState = window.AppState || {};
+        window.AppState.schema = schemaData;
 
-        buildMenu(schema, menuEl, gridTitleEl, addRowBtn);
-        const navList = menuEl.querySelector('ul') || menuEl;
-        
-        let dashName = 'Dashboard';
-        let dashIconEl = renderIconElement('', 'assets/icons/dashboard.png');
-        let calName = 'Calendar';
-        let calIconEl = renderIconElement('', 'assets/icons/calendar.png');
-
-        try {
-            const dashRes = await fetch('api.php?api=dashboard&v=' + Date.now());
-            if (dashRes.ok) {
-                const dashCfg = await dashRes.json();
-                if (dashCfg.menu_name) dashName = dashCfg.menu_name;
-                dashIconEl = renderIconElement(dashCfg.menu_icon, 'assets/icons/dashboard.png');
+        if (Object.keys(window.schema.tables).length > 0) {
+            
+            // Read URL params to check if dashboard redirected us to a specific table
+            const urlParams = new URLSearchParams(window.location.search);
+            const urlTable = urlParams.get('table');
+            
+            // Determine the initial table to load
+            let initialTableName = Object.keys(window.schema.tables)[0];
+            if (urlTable && window.schema.tables[urlTable]) {
+                initialTableName = urlTable;
             }
-        } catch(e) { console.warn('Could not load dashboard config', e); }
 
-        try {
-            const calRes = await fetch('api.php?api=calendar&v=' + Date.now());
-            if (calRes.ok) {
-                const calCfg = await calRes.json();
-                if (calCfg.menu_name) calName = calCfg.menu_name;
-                calIconEl = renderIconElement(calCfg.menu_icon, 'assets/icons/calendar.png');
+            buildMenu(window.schema, menuEl, gridTitleEl, addRowBtn);
+            const navList = menuEl.querySelector('ul') || menuEl;
+            
+            let dashName = 'Dashboard';
+            let dashIconEl = renderIconElement('', 'assets/icons/dashboard.png');
+            let calName = 'Calendar';
+            let calIconEl = renderIconElement('', 'assets/icons/calendar.png');
+
+            try {
+                const dashRes = await fetch('api.php?api=dashboard&v=' + Date.now());
+                if (dashRes.ok) {
+                    const dashCfg = await dashRes.json();
+                    if (dashCfg.menu_name) dashName = dashCfg.menu_name;
+                    dashIconEl = renderIconElement(dashCfg.menu_icon, 'assets/icons/dashboard.png');
+                }
+            } catch(e) { console.warn('Could not load dashboard config', e); }
+
+            try {
+                const calRes = await fetch('api.php?api=calendar&v=' + Date.now());
+                if (calRes.ok) {
+                    const calCfg = await calRes.json();
+                    if (calCfg.menu_name) calName = calCfg.menu_name;
+                    calIconEl = renderIconElement(calCfg.menu_icon, 'assets/icons/calendar.png');
+                }
+            } catch(e) { console.warn('Could not load calendar config', e); }
+
+            // Dashboard Item
+            const dashItem = document.createElement('li');
+            const dashLink = document.createElement('a');
+            dashLink.href = 'dashboard.php';
+            dashLink.className = 'custom-nav-link';
+            dashLink.appendChild(dashIconEl);
+            const dashSpan = document.createElement('span');
+            dashSpan.style.verticalAlign = 'middle';
+            dashSpan.textContent = dashName;
+            dashLink.appendChild(dashSpan);
+            dashItem.appendChild(dashLink);
+
+            // Calendar Item
+            const calItem = document.createElement('li');
+            const calLink = document.createElement('a');
+            calLink.href = 'calendar.php';
+            calLink.className = 'custom-nav-link';
+            calLink.appendChild(calIconEl);
+            const calSpan = document.createElement('span');
+            calSpan.style.verticalAlign = 'middle';
+            calSpan.textContent = calName;
+            calLink.appendChild(calSpan);
+            calItem.appendChild(calLink);
+
+            if (navList.tagName === 'UL') {
+                navList.prepend(calItem);
+                navList.prepend(dashItem);
+            } else {
+                menuEl.prepend(calLink);
+                menuEl.prepend(dashLink);
             }
-        } catch(e) { console.warn('Could not load calendar config', e); }
+            
+            // Dynamically create a container for Active Filter Pills
+            const gridSection = document.getElementById('gridSection');
+            if (gridSection) {
+                const pillsContainer = document.createElement('div');
+                pillsContainer.id = 'filterPills';
+                pillsContainer.style.cssText = 'display: none; gap: 8px; flex-wrap: wrap; padding: 0 1.25rem; background: var(--panel); border-bottom: 1px solid var(--border-light);';
+                gridTitleEl.after(pillsContainer);
+            }
 
-        // Dashboard Item
-        const dashItem = document.createElement('li');
-        const dashLink = document.createElement('a');
-        dashLink.href = 'dashboard.php';
-        dashLink.className = 'custom-nav-link';
-        dashLink.appendChild(dashIconEl);
-        const dashSpan = document.createElement('span');
-        dashSpan.style.verticalAlign = 'middle';
-        dashSpan.textContent = dashName;
-        dashLink.appendChild(dashSpan);
-        dashItem.appendChild(dashLink);
-
-        // Calendar Item
-        const calItem = document.createElement('li');
-        const calLink = document.createElement('a');
-        calLink.href = 'calendar.php';
-        calLink.className = 'custom-nav-link';
-        calLink.appendChild(calIconEl);
-        const calSpan = document.createElement('span');
-        calSpan.style.verticalAlign = 'middle';
-        calSpan.textContent = calName;
-        calLink.appendChild(calSpan);
-        calItem.appendChild(calLink);
-
-        if (navList.tagName === 'UL') {
-            navList.prepend(calItem);
-            navList.prepend(dashItem);
-        } else {
-            menuEl.prepend(calLink);
-            menuEl.prepend(dashLink);
+            const gridContainerEl = document.getElementById('grid');
+            if (gridContainerEl) { initWorkflows(navList, gridContainerEl, gridTitleEl); }
+            
+            // Load target table requested by URL
+            loadTable(window.schema, initialTableName, gridTitleEl, addRowBtn);
+            setupPagination(window.schema);
         }
-        
-        // Dynamically create a container for Active Filter Pills
-        const gridSection = document.getElementById('gridSection');
-        if (gridSection) {
-            const pillsContainer = document.createElement('div');
-            pillsContainer.id = 'filterPills';
-            pillsContainer.style.cssText = 'display: none; gap: 8px; flex-wrap: wrap; padding: 0 1.25rem; background: var(--panel); border-bottom: 1px solid var(--border-light);';
-            gridTitleEl.after(pillsContainer);
-        }
-
-        const gridContainerEl = document.getElementById('grid');
-        if (gridContainerEl) { initWorkflows(navList, gridContainerEl, gridTitleEl); }
-        
-        // Load target table requested by URL
-        loadTable(schema, initialTableName, gridTitleEl, addRowBtn);
-        setupPagination(schema);
+    } catch (error) {
+        console.error("Initialization error:", error);
     }
 });
 
@@ -138,12 +156,12 @@ function populateColumnFilter() {
         opt.value = col; 
         
         let displayName = col; 
-        if (currentTable && schema.tables[currentTable]?.columns[col]?.display_name) {
-            displayName = schema.tables[currentTable].columns[col].display_name;
+        if (currentTable && window.schema.tables[currentTable]?.columns[col]?.display_name) {
+            displayName = window.schema.tables[currentTable].columns[col].display_name;
         } else {
-            for (const tKey in schema.tables) {
-                if (schema.tables[tKey].columns[col]?.display_name) {
-                    displayName = schema.tables[tKey].columns[col].display_name;
+            for (const tKey in window.schema.tables) {
+                if (window.schema.tables[tKey].columns[col]?.display_name) {
+                    displayName = window.schema.tables[tKey].columns[col].display_name;
                     break;
                 }
             }
@@ -169,11 +187,11 @@ function handleColumnFilterChange() {
     const filterBar = document.getElementById('filterBar');
     
     filterBar.innerHTML = '';
-    if (!col || !currentTable || !schema.tables[currentTable]) return;
+    if (!col || !currentTable || !window.schema.tables[currentTable]) return;
 
-    const colCfg = schema.tables[currentTable].columns[col] || {};
+    const colCfg = window.schema.tables[currentTable].columns[col] || {};
     const type = (colCfg.type || '').toLowerCase();
-    const isFK = schema.tables[currentTable].foreign_keys && schema.tables[currentTable].foreign_keys[col];
+    const isFK = window.schema.tables[currentTable].foreign_keys && window.schema.tables[currentTable].foreign_keys[col];
 
     const existingFilter = activeFilters.columns[col] || {};
 
@@ -361,8 +379,8 @@ function renderFilterPills() {
 
     for (const [col, filter] of Object.entries(activeFilters.columns)) {
         let colName = col;
-        if (currentTable && schema.tables[currentTable]?.columns[col]?.display_name) {
-            colName = schema.tables[currentTable].columns[col].display_name;
+        if (currentTable && window.schema.tables[currentTable]?.columns[col]?.display_name) {
+            colName = window.schema.tables[currentTable].columns[col].display_name;
         }
 
         let label = '';
@@ -433,7 +451,7 @@ async function applySearch() {
     });
 
     setFilteredData(rows);
-    await renderGrid(schema);
+    await renderGrid(window.schema);
     renderFilterPills();
     updateClearFiltersVisibility();
     debugLog("Search Applied", { activeFilters, results: rows.length });
@@ -456,7 +474,7 @@ clearFiltersBtn.addEventListener('click', async () => {
     renderFilterPills();
     updateClearFiltersVisibility();
     
-    await resetFilters(schema);
+    await resetFilters(window.schema);
 });
 
 // Sync search input

--- a/assets/js/calendar.js
+++ b/assets/js/calendar.js
@@ -1,8 +1,8 @@
-// assets/js/calendar.js
+// Store current date state
 let currentMonth = new Date().getMonth();
 let currentYear = new Date().getFullYear();
 let eventsData = [];
-let appSchema = null; // Store schema object globally
+let appSchema = null; 
 
 // Init calendar when DOM is ready
 document.addEventListener('DOMContentLoaded', async () => {
@@ -29,32 +29,33 @@ document.addEventListener('DOMContentLoaded', async () => {
     });
 });
 
-// Fetch schema definition from backend
+// Fetch secure schema definition from backend API
 async function fetchSchema() {
-    if (typeof window.schema !== 'undefined') {
-        appSchema = window.schema;
-        return;
-    }
-    if (typeof schema !== 'undefined') {
-        appSchema = schema;
-        return;
-    }
     try {
-        const res = await fetch('includes/schema.json');
+        const res = await fetch('api_schema.php', {
+            headers: { 'X-Requested-With': 'XMLHttpRequest' }
+        });
         if (res.ok) {
             appSchema = await res.json();
+            window.schema = appSchema; 
+        } else {
+            console.error('Failed to load secure schema');
         }
     } catch (err) {
-        console.warn('Failed to fetch schema in calendar', err);
+        console.error('Failed to fetch schema in calendar', err);
     }
 }
 
 // Fetch calendar events via API
 async function fetchEvents() {
     try {
-        const res = await fetch('api.php?api=calendar');
-        const data = await res.json();
-        eventsData = data.events || [];
+        const res = await fetch('api.php?api=calendar', {
+            headers: { 'X-Requested-With': 'XMLHttpRequest' }
+        });
+        if (res.ok) {
+            const data = await res.json();
+            eventsData = data.events || [];
+        }
     } catch (err) {
         console.error('Failed to load calendar events', err);
     }
@@ -65,6 +66,7 @@ function renderCalendar() {
     const container = document.getElementById('calendarContainer');
     const title = document.getElementById('calendarTitle');
     
+    // Clear container safely
     container.innerHTML = '';
 
     // Initialize floating tooltip container
@@ -110,8 +112,8 @@ function renderCalendar() {
         dateNum.className = 'calendar-date-num';
         dateNum.textContent = i;
         cell.appendChild(dateNum);
-		
-		const todayDate = new Date();
+        
+        const todayDate = new Date();
         if (i === todayDate.getDate() && 
             currentMonth === todayDate.getMonth() && 
             currentYear === todayDate.getFullYear()) {
@@ -126,7 +128,7 @@ function renderCalendar() {
             evEl.className = 'calendar-event';
             evEl.style.backgroundColor = ev.color;
             
-            // Build icon safely without innerHTML
+            // Build icon safely
             if (ev.icon) {
                 if (ev.icon.includes('/') || ev.icon.includes('.')) {
                     const img = document.createElement('img');
@@ -145,8 +147,9 @@ function renderCalendar() {
             const titleText = document.createTextNode(ev.title);
             evEl.appendChild(titleText);
             
+            // Securely encode URL parameters
             evEl.addEventListener('click', () => {
-                window.location.href = `edit.php?table=${ev.table}&id=${ev.id}`;
+                window.location.href = `edit.php?table=${encodeURIComponent(ev.table)}&id=${encodeURIComponent(ev.id)}`;
             });
 
             // Handle tooltip hover event safely

--- a/assets/js/grid.js
+++ b/assets/js/grid.js
@@ -3,8 +3,8 @@ import { onCellBlur, onInputChange, deleteRow, addRow, attachCellEvents } from '
 import { setupPagination, getPageRows } from './pagination.js';
 import { exportCSV } from './export_csv.js';
 
-// Retrieve global user role
-const userRole = window.USER_ROLE || 'full';
+// Retrieve global user role with safe fallback
+const userRole = window.USER_ROLE || 'readonly';
 const isReadOnly = userRole === 'readonly';
 
 const fkCache = {};
@@ -13,35 +13,27 @@ let currentTable = null;
 let fullData = [];
 let displayedColumns = [];
 let filteredData = [];
-// Backup array for the third state of sorting
 let unsortedFilteredData = []; 
 let sortState = { column: null, asc: true };
 
-// Build dynamic menu from schema
+// Build dynamic menu from loaded schema
 export function buildMenu(schema, menuEl, gridTitleEl, addRowBtn) {
     const ul = document.createElement('ul');
     
-    // Check parameters to properly highlight active menu item
     const urlParams = new URLSearchParams(window.location.search);
     const urlTable = urlParams.get('table');
     const firstTable = Object.keys(schema.tables)[0];
     const initialTable = (urlTable && schema.tables[urlTable]) ? urlTable : firstTable;
   
     for (const [t, cfg] of Object.entries(schema.tables)) {
-        if (cfg.hidden === true) {
-            continue;
-        }
-
         const li = document.createElement('li');
         const a = document.createElement('a');
         a.href = '#';
 
-        // Add active class if this is the target table
         if (t === initialTable) {
             a.classList.add('active');
         }
 
-        // Append icon if it exists
         if (cfg.icon) {
             const img = document.createElement('img');
             img.src = cfg.icon;
@@ -53,13 +45,11 @@ export function buildMenu(schema, menuEl, gridTitleEl, addRowBtn) {
         textSpan.textContent = cfg.display_name || t;
         a.appendChild(textSpan);
 
-        // Handle menu item click
         a.onclick = e => {
             e.preventDefault();
             menuEl.querySelectorAll('a').forEach(link => link.classList.remove('active'));
             a.classList.add('active');
             
-            // Clear URL params when clicking menu items manually to reset filters
             window.history.pushState({}, document.title, window.location.pathname);
             loadTable(schema, t, gridTitleEl, addRowBtn);
         };
@@ -68,7 +58,8 @@ export function buildMenu(schema, menuEl, gridTitleEl, addRowBtn) {
         ul.appendChild(li);
     }
   
-    menuEl.innerHTML = '';
+    // Secure DOM clearing
+    menuEl.replaceChildren();
     menuEl.appendChild(ul);
     debugLog("Menu built", Object.keys(schema.tables));
 }
@@ -94,7 +85,7 @@ export async function loadTable(schema, table, gridTitleEl, addRowBtn) {
             }
         }
 
-        const res = await fetch(fetchUrl);
+        const res = await fetch(fetchUrl, { headers: { 'X-Requested-With': 'XMLHttpRequest' }});
         const data = await res.json();
 
         currentTable = table;
@@ -103,7 +94,6 @@ export async function loadTable(schema, table, gridTitleEl, addRowBtn) {
 
         fullData = data.rows || [];
     
-        // Filter out hidden columns and PK
         displayedColumns = (data.columns || []).filter(c => {
             if (c === 'id') return false;
             const colCfg = schema.tables[table].columns[c] || {};
@@ -111,7 +101,6 @@ export async function loadTable(schema, table, gridTitleEl, addRowBtn) {
             return true;
         });
 
-        // Set visual indicator for filtered view in the grid title
         let displayTitle = data.table?.display_name || table;
         if (urlParams.get('table') === table && filterCol && filterVal !== null) {
             displayTitle += ` (Filtered by ${filterCol}: ${filterVal})`;
@@ -122,29 +111,26 @@ export async function loadTable(schema, table, gridTitleEl, addRowBtn) {
         unsortedFilteredData = filteredData.slice(); 
         sortState = { column: null, asc: true };
 
-        // Handle add row button visibility based on user role
-        if (isReadOnly) {
-            addRowBtn.style.display = 'none';
-        } else {
-            addRowBtn.style.display = '';
-            addRowBtn.disabled = false;
-            // Redirect to create form on button click
-            addRowBtn.onclick = () => {
-                debugLog("Redirect to create form", { table: currentTable });
-                window.location.href = `create.php?table=${currentTable}`;
-            };
+        if (addRowBtn) {
+            if (isReadOnly) {
+                addRowBtn.style.display = 'none';
+            } else {
+                addRowBtn.style.display = '';
+                addRowBtn.disabled = false;
+                addRowBtn.onclick = () => {
+                    window.location.href = `create.php?table=${currentTable}`;
+                };
+            }
         }
 
         await renderGrid(schema);
-
-        // Dispatch event to re-init filters
         document.dispatchEvent(new Event("tableLoaded"));
     } catch (err) {
         console.error("Failed to load table data:", err);
     }
 }
 
-// Preload foreign key relations
+// Preload foreign key relations securely
 async function preloadForeignKeys(schema) {
     const fks = schema.tables[currentTable]?.foreign_keys;
     if (!fks) return;
@@ -154,20 +140,20 @@ async function preloadForeignKeys(schema) {
     for (const col of displayedColumns) {
         const fkCfg = fks[col];
         if (fkCfg) {
-            const refTable = fkCfg.reference_table;
-      
-            // Fetch related data if not cached
-            if (!fkCache[refTable]) {
-                fkCache[refTable] = fetch(`index.php?api=list&table=${encodeURIComponent(refTable)}`)
+            const cacheKey = `${currentTable}_${col}`;
+            
+            if (!fkCache[cacheKey]) {
+                fkCache[cacheKey] = fetch(`api_fk.php?table=${encodeURIComponent(currentTable)}&col=${encodeURIComponent(col)}`, {
+                    headers: { 'X-Requested-With': 'XMLHttpRequest' }
+                })
                 .then(res => res.json())
                 .then(refData => refData.rows || [])
                 .catch(err => {
-                    console.error(`Failed to fetch FK for ${refTable}`, err);
+                    console.error(`Failed to fetch FK for ${col}`, err);
                     return [];
                 });
             }
-      
-            fetchPromises.push(fkCache[refTable]);
+            fetchPromises.push(fkCache[cacheKey]);
         }
     }
 
@@ -187,27 +173,22 @@ export async function renderGrid(schema) {
     const thead = document.createElement('thead');
     const headRow = document.createElement('tr');
 
-    // Add expand column for subtables
     if (hasSubtables) {
         const thExpand = document.createElement('th');
         thExpand.style.width = '30px';
         headRow.appendChild(thExpand);
     }
 
-    // Create table headers with Resize and Drag and Drop features
     displayedColumns.forEach(col => {
         const th = document.createElement('th');
         const colCfg = schema.tables[currentTable].columns[col] || {};
         th.textContent = colCfg.display_name || col;
         th.dataset.col = col; 
 
-        // Column Sorting Logic
         th.style.cursor = 'pointer';
         th.addEventListener('click', (e) => {
-            // Ignore click if user clicked on the resizer handle
             if (e.target.classList.contains('col-resizer')) return;
 
-            // Handle 3-state sorting logic
             if (sortState.column === col) {
                 if (sortState.asc === true) {
                     sortState.asc = false;
@@ -220,22 +201,15 @@ export async function renderGrid(schema) {
                 sortState.asc = true;
             }
 
-            // Restore array to unsorted base before applying new sort
             filteredData = unsortedFilteredData.slice();
-
-            if (sortState.column) {
-                sortData();
-            }
-
+            if (sortState.column) sortData();
             renderGrid(schema);
         });
 
-        // Add sort indicator
         if (sortState.column === col) {
             th.textContent += sortState.asc ? ' ↑' : ' ↓';
         }
 
-        // Column Resizer Logic
         const resizer = document.createElement('div');
         resizer.className = 'col-resizer';
         th.appendChild(resizer);
@@ -265,7 +239,6 @@ export async function renderGrid(schema) {
             document.addEventListener('mouseup', onMouseUp);
         });
 
-        // Drag and Drop Column Reordering Logic
         th.draggable = true;
         
         th.addEventListener('dragstart', (e) => {
@@ -274,9 +247,7 @@ export async function renderGrid(schema) {
             setTimeout(() => th.classList.add('dragging'), 0);
         });
 
-        th.addEventListener('dragend', () => {
-            th.classList.remove('dragging');
-        });
+        th.addEventListener('dragend', () => th.classList.remove('dragging'));
 
         th.addEventListener('dragover', (e) => {
             e.preventDefault(); 
@@ -284,9 +255,7 @@ export async function renderGrid(schema) {
             th.classList.add('drag-over');
         });
 
-        th.addEventListener('dragleave', () => {
-            th.classList.remove('drag-over');
-        });
+        th.addEventListener('dragleave', () => th.classList.remove('drag-over'));
 
         th.addEventListener('drop', (e) => {
             e.preventDefault();
@@ -308,7 +277,6 @@ export async function renderGrid(schema) {
         headRow.appendChild(th);
     });
 
-    // Render Actions header only for full permission users
     if (!isReadOnly) {
         const thActions = document.createElement('th');
         thActions.textContent = 'Actions';
@@ -324,7 +292,6 @@ export async function renderGrid(schema) {
     for (const row of pageRows) {
         const tr = document.createElement('tr');
 
-        // Handle subtable drilldown
         if (hasSubtables) {
             const tdExpand = document.createElement('td');
             const btnExpand = document.createElement('button');
@@ -342,11 +309,16 @@ export async function renderGrid(schema) {
                     ddTr.className = 'drilldown-row';
                     const ddTd = document.createElement('td');
                     ddTd.colSpan = displayedColumns.length + (isReadOnly ? 1 : 2); 
-                    ddTd.innerHTML = '<em>Loading...</em>';
+                    
+                    // Secure loading element creation
+                    const loadingEl = document.createElement('em');
+                    loadingEl.textContent = 'Loading...';
+                    ddTd.appendChild(loadingEl);
+                    
                     ddTr.appendChild(ddTd);
                     tr.after(ddTr);
 
-                    ddTd.innerHTML = '';
+                    ddTd.replaceChildren();
                     
                     for (const sub of subtables) {
                         const subWrapper = document.createElement('div');
@@ -361,9 +333,10 @@ export async function renderGrid(schema) {
                         subTitle.style.color = 'var(--text)';
                         subWrapper.appendChild(subTitle);
 
-                        // Fetch related subtable rows
                         try {
-                            const res = await fetch(`index.php?api=list&table=${encodeURIComponent(sub.table)}&filter_col=${encodeURIComponent(sub.foreign_key)}&filter_val=${encodeURIComponent(row.id)}`);
+                            const res = await fetch(`api.php?api=list&table=${encodeURIComponent(sub.table)}&filter_col=${encodeURIComponent(sub.foreign_key)}&filter_val=${encodeURIComponent(row.id)}`, {
+                                headers: { 'X-Requested-With': 'XMLHttpRequest' }
+                            });
                             const data = await res.json();
                             
                             const ul = document.createElement('ul');
@@ -401,7 +374,12 @@ export async function renderGrid(schema) {
                             }
                             subWrapper.appendChild(ul);
                         } catch(err) {
-                            subWrapper.innerHTML += '<p style="color:var(--danger); font-size:13px;">Error fetching data.</p>';
+                            // Secure error element creation
+                            const errP = document.createElement('p');
+                            errP.style.color = 'var(--danger)';
+                            errP.style.fontSize = '13px';
+                            errP.textContent = 'Error fetching data.';
+                            subWrapper.appendChild(errP);
                         }
 
                         ddTd.appendChild(subWrapper);
@@ -419,12 +397,10 @@ export async function renderGrid(schema) {
 
             const fkCfg = schema.tables[currentTable].foreign_keys?.[col];
 
-            // Handle Foreign Key rendering with datalist for searchability
             if (fkCfg) {
                 const td = document.createElement('td');
                 const input = document.createElement('input');
                 
-                // Use type search to add native clear button in browsers
                 input.type = 'search'; 
                 
                 const dlId = `fk_${currentTable}_${col}_${row['id']}`;
@@ -440,23 +416,18 @@ export async function renderGrid(schema) {
                 const datalist = document.createElement('datalist');
                 datalist.id = dlId;
 
-                const refTable = fkCfg.reference_table;
-                const refCol = fkCfg.reference_column || 'id';
-                
-                // Safely parse display_column to array
                 const dispCols = Array.isArray(fkCfg.display_column) ? fkCfg.display_column : [fkCfg.display_column || 'id'];
-
+                const cacheKey = `${currentTable}_${col}`;
                 let currentDisplay = "";
 
-                if (fkCache[refTable]) {
-                    const refData = await fkCache[refTable];
+                if (fkCache[cacheKey]) {
+                    const refData = await fkCache[cacheKey];
                     refData.forEach(r => {
                         const option = document.createElement('option');
+                        const refCol = 'id'; 
                         const displayValue = dispCols.map(c => r[c + '__display'] ?? r[c] ?? '').join(' - ') || r[refCol];
                         
                         option.value = displayValue;
-                        
-                        // Hide the real database ID in a hidden data attribute
                         option.dataset.realId = r[refCol]; 
 
                         if (String(r[refCol]) === String(row[col])) {
@@ -469,12 +440,10 @@ export async function renderGrid(schema) {
 
                 input.value = currentDisplay;
 
-                // Select all text on click to allow fast overriding
                 input.addEventListener('focus', () => {
                     input.select();
                 });
 
-                // Revert to the last valid name upon leaving the cell
                 input.addEventListener('blur', () => {
                     const isValid = Array.from(datalist.options).some(o => o.value === input.value);
                     
@@ -494,7 +463,6 @@ export async function renderGrid(schema) {
 
             const td = document.createElement('td');
 
-            // Render enum as dropdown
             if (type === 'enum') {
                 const select = document.createElement('select');
                 select.dataset.column = col;
@@ -534,14 +502,10 @@ export async function renderGrid(schema) {
                     select.disabled = true;
                 }
 
-                select.addEventListener('change', (e) => {
-                    applyEnumColor(e.target.value);
-                });
-
+                select.addEventListener('change', (e) => applyEnumColor(e.target.value));
                 if (!isReadOnly) attachCellEvents(select);
                 td.appendChild(select);
             }
-            // Render boolean as checkbox
             else if (type.includes('boolean')) {
                 const input = document.createElement('input');
                 input.type = 'checkbox';
@@ -549,14 +513,10 @@ export async function renderGrid(schema) {
                 input.dataset.column = col;
                 input.dataset.id = row['id'];
 
-                if (colCfg.readonly || isReadOnly) {
-                    input.disabled = true;
-                }
-
+                if (colCfg.readonly || isReadOnly) input.disabled = true;
                 if (!isReadOnly) attachCellEvents(input);
                 td.appendChild(input);
             }
-            // Render date picker
             else if (type.includes('date')) {
                 const input = document.createElement('input');
                 input.type = 'date';
@@ -564,14 +524,10 @@ export async function renderGrid(schema) {
                 input.dataset.column = col;
                 input.dataset.id = row['id'];
 
-                if (colCfg.readonly || isReadOnly) {
-                    input.disabled = true;
-                }
-
+                if (colCfg.readonly || isReadOnly) input.disabled = true;
                 if (!isReadOnly) attachCellEvents(input);
                 td.appendChild(input);
             }
-            // Render editable text cell
             else {
                 if (!colCfg.readonly && !isReadOnly) {
                     td.contentEditable = 'true';
@@ -589,7 +545,6 @@ export async function renderGrid(schema) {
                 const strVal = String(value).trim();
                 const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
                 
-                // Handle URL links
                 if (/^https?:\/\//i.test(strVal)) {
                     const a = document.createElement('a');
                     a.href = strVal;
@@ -603,10 +558,8 @@ export async function renderGrid(schema) {
                         e.preventDefault();
                         window.open(strVal, '_blank');
                     });
-
                     td.appendChild(a);
                 } 
-                // Handle email links
                 else if (emailRegex.test(strVal)) {
                     const a = document.createElement('a');
                     a.href = `mailto:${strVal}`;
@@ -615,10 +568,7 @@ export async function renderGrid(schema) {
                     a.style.textDecoration = 'underline';
                     a.style.cursor = 'pointer';
                     
-                    a.addEventListener('click', (e) => {
-                        e.stopPropagation();
-                    });
-
+                    a.addEventListener('click', (e) => e.stopPropagation());
                     td.appendChild(a);
                 } else {
                     td.textContent = value;
@@ -643,11 +593,9 @@ export async function renderGrid(schema) {
             tr.appendChild(td);
         }
 
-        // Render action buttons only if user is not readonly
         if (!isReadOnly) {
             const tdActions = document.createElement('td');
             
-            // Edit action button
             const editBtn = document.createElement('button');
             editBtn.textContent = 'Edit';
             editBtn.style.marginRight = '8px';
@@ -656,7 +604,6 @@ export async function renderGrid(schema) {
             });
             tdActions.appendChild(editBtn);
 
-            // Delete action button
             const delBtn = document.createElement('button');
             delBtn.textContent = 'Delete';
             delBtn.className = 'danger';
@@ -681,11 +628,10 @@ export async function renderGrid(schema) {
     }
 
     table.appendChild(tbody);
-    gridEl.innerHTML = '';
+    gridEl.replaceChildren();
     gridEl.appendChild(table);
 
     setupPagination(schema);
-
     debugLog("Grid rendered", { rows: pageRows.length });
 }
 
@@ -716,14 +662,12 @@ function sortData() {
     });
 }
 
-// Convert dates to standard ISO format for input fields
+// Convert dates to standard format
 function normalizeDateValue(value) {
     if (!value) return '';
     if (typeof value === 'string') {
         const dbMatch = value.match(/^(\d{4}-\d{2}-\d{2})/);
-        if (dbMatch) {
-            return dbMatch[1];
-        }
+        if (dbMatch) return dbMatch[1];
 
         const iso = value.includes('T') ? value.split('T')[0] : value;
         const m = iso.match(/^(\d{2})\.(\d{2})\.(\d{4})$/);
@@ -743,14 +687,10 @@ export function getState() {
 export function setFilteredData(rows) {
     filteredData = rows;
     unsortedFilteredData = rows.slice();
-  
-    // Re-apply sort if currently active
-    if (sortState.column) {
-        sortData();
-    }
+    if (sortState.column) sortData();
 }
 
-// Reset filtered data to full dataset and re render
+// Reset filters
 export async function resetFilters(schema) {
     filteredData = fullData.slice();
     unsortedFilteredData = fullData.slice();
@@ -758,12 +698,8 @@ export async function resetFilters(schema) {
     await renderGrid(schema);
 }
 
-// Initialize export button event listener
+// Setup export event listener
 document.addEventListener('DOMContentLoaded', () => {
     const btn = document.getElementById('exportCsv');
-    if (btn) {
-        btn.addEventListener('click', exportCSV);
-    } else {
-        console.error("Export CSV button not found");
-    }
+    if (btn) btn.addEventListener('click', exportCSV);
 });

--- a/calendar.php
+++ b/calendar.php
@@ -1,10 +1,14 @@
 <?php
-
 session_start();
+
+// Redirect to login if not authenticated
 if (!isset($_SESSION['user_id'])) {
     header("Location: login.php");
     exit;
 }
+
+// Define strict user role
+$userRole = $_SESSION['role'] ?? 'readonly';
 ?>
 <!doctype html>
 <html lang="en">
@@ -102,16 +106,16 @@ if (!isset($_SESSION['user_id'])) {
 </main>
 
 <script>
-    // Load schema globally from PHP to avoid direct HTTP access to /includes
-    const schema = <?php echo file_get_contents(__DIR__ . '/includes/schema.json'); ?>;
+    // Define global user role state
+    window.USER_ROLE = '<?php echo htmlspecialchars($userRole ?? 'readonly', ENT_QUOTES, 'UTF-8'); ?>';
 </script>
 
-<script type="module" src="assets/js/calendar.js"></script>
+<script type="module" src="assets/js/calendar.js?v=<?php echo @filemtime('assets/js/calendar.js'); ?>"></script>
 
 <footer>
     <div class="footer-content">
         <small>
-            <a href="https://opensparrow.org/">OpenSparrow.org</a> | Open source | LGPL v3. | PHP + vanilla JS + Postgres!
+            <a href="https://opensparrow.org/">OpenSparrow.org</a> | Open source | LGPL v3. | PHP + vanilla JS + Postgres
         </small>
     </div>
 </footer>

--- a/index.php
+++ b/index.php
@@ -1,31 +1,20 @@
 <?php
-
 session_start();
+
+// Redirect to login if user is not authenticated
 if (!isset($_SESSION['user_id'])) {
     header("Location: login.php");
     exit;
 }
 
-// 1. If this is an API call -> pass control to api.php and exit
+// Define strict user role
+$userRole = $_SESSION['role'] ?? 'readonly';
+
+// Route API requests directly to api.php
 if (isset($_GET['api'])) {
     require __DIR__ . '/api.php';
     exit;
 }
 
-// 2. If this is a standard request -> load the schema for the template
-$schemaPath = __DIR__ . '/includes/schema.json';
-
-if (!file_exists($schemaPath)) {
-    http_response_code(500);
-    die('Error: Missing schema.json configuration file');
-}
-
-$schemaJson = file_get_contents($schemaPath);
-
-if ($schemaJson === false) {
-    http_response_code(500);
-    die('Error: Cannot read schema.json file');
-}
-
-// 3. Render the view
+// Load the UI template (schema is no longer injected here)
 include __DIR__ . '/templates/template.php';

--- a/templates/template.php
+++ b/templates/template.php
@@ -66,12 +66,16 @@
             </div>
         </div>
 
+        <?php if (($userRole ?? '') === 'full') : ?>
         <a href="/admin/index.php" title="Admin" 
            style="text-decoration: none; font-size: 20px; margin-right: 15px; 
-                  vertical-align: middle; display: inline-block; transition: opacity 0.2s;"><img style="height:20px;"  title="Admin panel" src="assets/img/settings.png"></a>
+                  vertical-align: middle; display: inline-block; transition: opacity 0.2s;">
+           <img style="height:20px;" title="Admin panel" src="assets/img/settings.png">
+        </a>
+        <?php endif; ?>
         
         <?php if (isset($_SESSION['username'])) : ?>
-            <span class="header-username"><?= htmlspecialchars($_SESSION['username']) ?></span>
+            <span class="header-username"><?= htmlspecialchars($_SESSION['username'], ENT_QUOTES, 'UTF-8') ?></span>
         <?php endif; ?>
         
         <button onclick="window.location.href='logout.php'" class="btn-logout">
@@ -92,12 +96,16 @@
             <div class="left">
                 <select id="mobileActions">
                     <option value="">Choose action…</option>
+                    <?php if (($userRole ?? '') === 'full') : ?>
                     <option value="add">Add row</option>
+                    <?php endif; ?>
                     <option value="export">Export CSV</option>
                     <option value="refresh">Refresh table</option>
                 </select>
 
-                <button id="addRow" class="success" disabled>Add</button>
+                <?php if (($userRole ?? '') === 'full') : ?>
+                <button id="addRow" class="success">Add</button>
+                <?php endif; ?>
                 <button id="exportCsv">Export CSV</button>
             </div>
 
@@ -111,24 +119,30 @@
 <footer>
     <div class="footer-content">
         <small>
-            <a href="https://opensparrow.org/">OpenSparrow.org</a> | Open source | LGPL v3. | PHP + vanilla JS + Postgres!
+            <a href="https://opensparrow.org/">OpenSparrow.org</a> | Open source | LGPL v3. | PHP + vanilla JS + Postgres
         </small>
     </div>
 </footer>
 
 <script>
-    const schema = <?php echo isset($schemaJson) ? $schemaJson : '{}'; ?>;
+    // Define global user role state
+    window.USER_ROLE = '<?php echo htmlspecialchars($userRole ?? 'readonly', ENT_QUOTES, 'UTF-8'); ?>';
 
     document.addEventListener("DOMContentLoaded", () => {
-        
         const mobileActions = document.getElementById("mobileActions");
         const menu = document.getElementById("menu");
 
         if (mobileActions) {
             mobileActions.addEventListener("change", e => {
                 const action = e.target.value;
-                if (action === "add") document.getElementById("addRow").click();
-                if (action === "export") document.getElementById("exportCsv").click();
+                if (action === "add") {
+                    const addBtn = document.getElementById("addRow");
+                    if (addBtn) addBtn.click();
+                }
+                if (action === "export") {
+                    const exportBtn = document.getElementById("exportCsv");
+                    if (exportBtn) exportBtn.click();
+                }
                 if (action === "refresh") location.reload();
                 mobileActions.value = "";
             });
@@ -141,13 +155,17 @@
 
         async function checkNotifications() {
             try {
-                const res = await fetch('api_notifications.php?action=get_count');
+                const res = await fetch('api_notifications.php?action=get_count', {
+                    headers: { 'X-Requested-With': 'XMLHttpRequest' }
+                });
                 const data = await res.json();
                 if (data.count > 0) {
-                    document.getElementById('notif-badge').style.display = 'block';
-                    document.getElementById('notif-badge').textContent = data.count;
+                    if (badge) {
+                        badge.style.display = 'block';
+                        badge.textContent = data.count;
+                    }
                 } else {
-                    document.getElementById('notif-badge').style.display = 'none';
+                    if (badge) badge.style.display = 'none';
                 }
             } catch (error) {
                 console.error('Error checking notifications:', error);
@@ -159,7 +177,6 @@
                 e.stopPropagation();
                 if (dropdown.style.display === 'none') {
                     dropdown.style.display = 'block';
-                    // Load notifications when opening
                     loadNotifications();
                 } else {
                     dropdown.style.display = 'none';
@@ -167,40 +184,39 @@
             });
         }
 
-        // Handle clicks outside the notifications dropdown
         document.addEventListener('click', (e) => {
             if (wrapper && !e.target.closest('.notifications-wrapper')) {
-                dropdown.style.display = 'none';
+                if (dropdown) dropdown.style.display = 'none';
             }
         });
 
-        // Load notifications function
         function loadNotifications() {
-            fetch('api_notifications.php?action=get_list')
-                .then(response => response.json())
-                .then(data => {
-                    notifList.innerHTML = '';
-                    if (data.length > 0) {
-                        data.forEach(notification => {
-                            const li = document.createElement('li');
-                            li.style.padding = '15px';
-                            li.style.textAlign = 'center';
-                            li.style.color = '#777';
-                            li.textContent = notification.title;
-                            notifList.appendChild(li);
-                        });
-                    } else {
-                        const emptyMsg = document.createElement('li');
-                        emptyMsg.style.padding = '15px';
-                        emptyMsg.style.textAlign = 'center';
-                        emptyMsg.style.color = '#777';
-                        emptyMsg.textContent = 'No new notifications';
-                        notifList.appendChild(emptyMsg);
-                    }
-                })
-                .catch(error => {
-                    console.error('Error loading notifications:', error);
-                });
+            fetch('api_notifications.php?action=get_list', {
+                headers: { 'X-Requested-With': 'XMLHttpRequest' }
+            })
+            .then(response => response.json())
+            .then(data => {
+                if (!notifList) return;
+                notifList.innerHTML = '';
+                if (data.length > 0) {
+                    data.forEach(notification => {
+                        const li = document.createElement('li');
+                        li.style.padding = '15px';
+                        li.style.textAlign = 'center';
+                        li.style.color = '#777';
+                        li.textContent = notification.title;
+                        notifList.appendChild(li);
+                    });
+                } else {
+                    const emptyMsg = document.createElement('li');
+                    emptyMsg.style.padding = '15px';
+                    emptyMsg.style.textAlign = 'center';
+                    emptyMsg.style.color = '#777';
+                    emptyMsg.textContent = 'No new notifications';
+                    notifList.appendChild(emptyMsg);
+                }
+            })
+            .catch(error => console.error('Error loading notifications:', error));
         }
 
         checkNotifications();
@@ -208,9 +224,7 @@
     });
 </script>
 
-<script type="module" 
-        src="assets/js/app.js?v=<?php echo filemtime('assets/js/app.js'); ?>">
-</script>
+<script type="module" src="assets/js/app.js?v=<?php echo @filemtime('assets/js/app.js'); ?>"></script>
 
 </body>
 </html>


### PR DESCRIPTION
Introduce api_schema.php and api_fk.php to serve a restricted, AJAX-only schema and to resolve foreign-key lists via the main API. Remove server-side injection of includes/schema.json into templates and fetch schema from the new API (app.js, calendar.js). Harden authentication and session checks (index.php, calendar.php), enforce AJAX headers, disable HTML error output in API endpoints, add caching/JSON headers and stricter method handling. Update frontend (assets/js/app.js, calendar.js, grid.js) to use window.schema, safer DOM manipulation (replaceChildren, avoid innerHTML), encode URL params, use X-Requested-With on fetches, better FK caching and fetching via api_fk.php, and respect readonly user role throughout UI and actions. Template tweaks: conditional admin/add controls based on role, sanitized username output, and safer notification loading. Overall changes improve security, reduce direct filesystem exposure of schema, and make frontend/backend interactions more robust.

## Description
Security

## Related Issue
Fixes #38 

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have tested these changes manually