### PR TITLE
Add calendar drag-and-drop move_event support

### DIFF
--- a/api.php
+++ b/api.php
@@ -382,6 +382,92 @@ try {
         $schemaName = $tableCfg['schema'] ?? 'public';
         $idCol = id_column();
 
+        // POST: CALENDAR MOVE EVENT (Drag & Drop functionality)
+        if ($method === 'POST' && ($body['api'] ?? '') === 'calendar' && ($body['action'] ?? '') === 'move_event') {
+            if ($role === 'readonly') {
+                http_response_code(403);
+                echo json_encode(['error' => 'Forbidden']);
+                exit;
+            }
+
+            // Load calendar configuration to validate source tables
+            $calPath = __DIR__ . '/includes/calendar.json';
+            $calConfig = file_exists($calPath) ? json_decode(file_get_contents($calPath), true) : ['sources' => []];
+            $sources = $calConfig['sources'] ?? [];
+
+            // Whitelist payload table against calendar.json sources
+            $allowedTables = array_column($sources, 'table');
+            if (!in_array($table, $allowedTables, true)) {
+                http_response_code(400);
+                echo json_encode(['error' => 'Invalid table']);
+                exit;
+            }
+
+            $id = (int)($body['id'] ?? 0);
+            $newDate = $body['newDate'] ?? '';
+
+            if ($id <= 0) {
+                http_response_code(400);
+                echo json_encode(['error' => 'Invalid ID']);
+                exit;
+            }
+
+            // Validate strict YYYY-MM-DD date format
+            if (!preg_match('/^\d{4}-\d{2}-\d{2}$/', $newDate) || !checkdate((int)substr($newDate, 5, 2), (int)substr($newDate, 8, 2), (int)substr($newDate, 0, 4))) {
+                http_response_code(400);
+                echo json_encode(['error' => 'Invalid date format']);
+                exit;
+            }
+
+            // Get date column for specific table configuration
+            $dateColumn = '';
+            foreach ($sources as $source) {
+                if ($source['table'] === $table) {
+                    $dateColumn = $source['date_column'];
+                    break;
+                }
+            }
+
+            if ($dateColumn === '') {
+                http_response_code(400);
+                echo json_encode(['error' => 'Missing date column config']);
+                exit;
+            }
+
+            // Perform safety regex check on column identifier
+            if (!preg_match('/^[a-zA-Z_][a-zA-Z0-9_]*$/', $dateColumn)) {
+                http_response_code(400);
+                echo json_encode(['error' => 'Invalid column name']);
+                exit;
+            }
+
+            // Update record via native pg_query_params for robust SQL injection prevention
+            $sql = sprintf(
+                'UPDATE "%s"."%s" SET "%s" = $1 WHERE %s = $2',
+                $schemaName,
+                $table,
+                $dateColumn,
+                pg_ident($idCol)
+            );
+
+            $res = @pg_query_params($conn, $sql, [$newDate, $id]);
+            if (!$res) {
+                http_response_code(500);
+                echo json_encode(['error' => 'Database error']);
+                error_log('Calendar move_event error: ' . pg_last_error($conn));
+                exit;
+            }
+
+            if (pg_affected_rows($res) === 0) {
+                http_response_code(404);
+                echo json_encode(['error' => 'Record not found']);
+                exit;
+            }
+
+            echo json_encode(['success' => true]);
+            exit;
+        }
+
         // PATCH: UPDATE SINGLE CELL
         if ($method === 'PATCH' && isset($body['id'], $body['column'], $body['value'])) {
             $col = $body['column'];

--- a/assets/js/calendar.js
+++ b/assets/js/calendar.js
@@ -122,12 +122,104 @@ function renderCalendar() {
 
         const dateString = `${currentYear}-${String(currentMonth + 1).padStart(2, '0')}-${String(i).padStart(2, '0')}`;
         
+        // Handle dragover required for dropping
+        cell.addEventListener('dragover', (e) => {
+            e.preventDefault(); 
+            e.dataTransfer.dropEffect = 'move';
+            cell.style.outline = '2px solid #6366f1'; 
+        });
+
+        // Handle dragleave
+        cell.addEventListener('dragleave', () => {
+            cell.style.outline = '';
+        });
+
+        // Handle dropping the event into a new date cell
+        cell.addEventListener('drop', async (e) => {
+            e.preventDefault();
+            cell.style.outline = '';
+
+            let payload;
+            try {
+                payload = JSON.parse(e.dataTransfer.getData('application/json'));
+            } catch {
+                return;
+            }
+
+            // Do nothing if dropped on the exact same date
+            if (payload.date === dateString) return;
+
+            // Optimistic UI update immediately reflects changes
+            const eventIndex = eventsData.findIndex(ev => ev.id === payload.id && ev.table === payload.table);
+            const originalDate = payload.date;
+            
+            if (eventIndex !== -1) {
+                eventsData[eventIndex].date = dateString;
+                renderCalendar(); 
+            }
+
+            // Dispatch fetch to update backend
+            try {
+                const res = await fetch('api.php', {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json',
+                        'X-Requested-With': 'XMLHttpRequest'
+                    },
+                    body: JSON.stringify({
+                        api: 'calendar',
+                        action: 'move_event',
+                        id: payload.id,
+                        table: payload.table,
+                        newDate: dateString
+                    })
+                });
+
+                const data = await res.json();
+
+                if (!res.ok || data.error) {
+                    // Rollback optimistic update on error
+                    if (eventIndex !== -1) {
+                        eventsData[eventIndex].date = originalDate;
+                        renderCalendar();
+                    }
+                    console.error('Failed to move event:', data.error ?? res.status);
+                }
+            } catch (err) {
+                // Rollback optimistic update on network failure
+                if (eventIndex !== -1) {
+                    eventsData[eventIndex].date = originalDate;
+                    renderCalendar();
+                }
+                console.error('Network error during event move:', err);
+            }
+        });
+
         const dayEvents = eventsData.filter(e => e.date === dateString);
         dayEvents.forEach(ev => {
             const evEl = document.createElement('div');
             evEl.className = 'calendar-event';
             evEl.style.backgroundColor = ev.color;
             
+            // Allow element to be dragged
+            evEl.draggable = true;
+
+            // Prepare payload and styles when drag starts
+            evEl.addEventListener('dragstart', (e) => {
+                e.dataTransfer.effectAllowed = 'move';
+                e.dataTransfer.setData('application/json', JSON.stringify({
+                    id: ev.id,
+                    table: ev.table,
+                    date: ev.date 
+                }));
+                evEl.style.opacity = '0.4'; 
+            });
+
+            // Clean up styles when drag ends
+            evEl.addEventListener('dragend', () => {
+                evEl.style.opacity = '';
+            });
+
             // Build icon safely
             if (ev.icon) {
                 if (ev.icon.includes('/') || ev.icon.includes('.')) {


### PR DESCRIPTION
Implement drag-and-drop event moving: add a POST api.php handler (api=calendar, action=move_event) that validates role, whitelists tables from includes/calendar.json, enforces strict YYYY-MM-DD dates, validates column identifiers, and updates the record via pg_query_params with error handling and logging. Update assets/js/calendar.js to enable draggable events and date cells (dragstart/dragend, dragover/dragleave, drop), perform optimistic UI updates, send the move request, and rollback on failure. This enables safe client-side dragging with robust server-side validation and SQL injection protection.

## Description
Implement drag-and-drop event moving.

## Related Issue
Fixes #40 

## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have tested these changes manually
- [ ] (Optional) I have updated the documentation