### PR TITLE
unsaved-changes guard, inline feedback, shared settings helper, secur…

### DIFF
--- a/admin/api.php
+++ b/admin/api.php
@@ -14,6 +14,16 @@ $action = $_GET['action'] ?? '';
 $file = $_GET['file'] ?? '';
 // Set this to false for GitHub public release
 $isDemoMode = false;
+
+// Never leak raw Postgres errors (schema names, constraint names, column lists)
+// into the HTTP response. Details go to the PHP error log; the client gets a
+// stable, generic message so the operator knows to check the server logs.
+function admin_db_fail($conn, string $context): void
+{
+    $raw = $conn !== null ? pg_last_error($conn) : 'no connection';
+    error_log('[admin_api][' . $context . '] ' . $raw);
+    throw new RuntimeException('Database operation failed. Check server logs for details.');
+}
 // CSRF Protection for state-changing POST requests
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $csrfToken = $_SERVER['HTTP_X_CSRF_TOKEN'] ?? $_POST['csrf_token'] ?? '';
@@ -71,7 +81,7 @@ if ($action === 'init_db') {
         foreach ($queries as $q) {
             $res = @pg_query($conn, $q);
             if (!$res) {
-                throw new Exception(pg_last_error($conn));
+                admin_db_fail($conn, 'init_db');
             }
         }
 
@@ -97,7 +107,7 @@ if ($action === 'users_list') {
             if (str_contains($err, 'is_active') || str_contains($err, 'does not exist')) {
                 throw new Exception("Database schema is outdated or missing. Please initialize tables.");
             }
-            throw new Exception($err);
+            admin_db_fail($conn, 'users_list');
         }
 
         $users = [];
@@ -138,7 +148,7 @@ if ($action === 'users_add') {
         $sql = "INSERT INTO " . sys_table('users') . " (username, password_hash, is_active, role) VALUES ($1, $2, true, $3)";
         $res = @pg_query_params($conn, $sql, [$username, $hash, $role]);
         if (!$res) {
-            throw new Exception(pg_last_error($conn));
+            admin_db_fail($conn, 'users_add');
         }
         echo json_encode(['status' => 'success']);
     } catch (Exception $e) {
@@ -169,7 +179,7 @@ if ($action === 'users_toggle') {
         $sql = "UPDATE " . sys_table('users') . " SET is_active = $1 WHERE id = $2";
         $res = @pg_query_params($conn, $sql, [$isActive ? 'true' : 'false', $userId]);
         if (!$res) {
-            throw new Exception(pg_last_error($conn));
+            admin_db_fail($conn, 'users_toggle');
         }
         echo json_encode(['status' => 'success']);
     } catch (Exception $e) {
@@ -201,7 +211,7 @@ if ($action === 'users_update_role') {
         $sql = "UPDATE " . sys_table('users') . " SET role = $1 WHERE id = $2";
         $res = @pg_query_params($conn, $sql, [$role, $userId]);
         if (!$res) {
-            throw new Exception(pg_last_error($conn));
+            admin_db_fail($conn, 'users_update_role');
         }
         echo json_encode(['status' => 'success']);
     } catch (Exception $e) {
@@ -237,7 +247,7 @@ if ($action === 'create_table') {
         $res = @pg_query($conn, $sql);
 
         if (!$res) {
-            throw new Exception(pg_last_error($conn));
+            admin_db_fail($conn, 'create_table');
         }
 
         echo json_encode(['status' => 'success']);
@@ -282,7 +292,7 @@ if ($action === 'add_column') {
         $res = @pg_query($conn, $sql);
 
         if (!$res) {
-            throw new Exception(pg_last_error($conn));
+            admin_db_fail($conn, 'add_column');
         }
 
         echo json_encode(['status' => 'success']);
@@ -507,7 +517,7 @@ if ($action === 'sync_schema') {
         $sql = "SELECT table_name FROM information_schema.tables WHERE table_schema = $1 AND table_type = 'BASE TABLE' AND table_name NOT LIKE 'spw\\_%' ESCAPE '\\'";
         $res = @pg_query_params($conn, $sql, [$schemaName]);
         if (!$res) {
-            throw new Exception(pg_last_error($conn));
+            admin_db_fail($conn, 'sync_schema');
         }
 
         $tables = [];
@@ -537,7 +547,7 @@ if ($action === 'get_db_columns') {
         $sql = "SELECT column_name, data_type, is_nullable, udt_name FROM information_schema.columns WHERE table_schema = $1 AND table_name = $2";
         $res = @pg_query_params($conn, $sql, [$schemaName, $tableName]);
         if (!$res) {
-            throw new Exception(pg_last_error($conn));
+            admin_db_fail($conn, 'get_db_columns');
         }
 
         $columns = [];

--- a/admin/app.js
+++ b/admin/app.js
@@ -1,25 +1,59 @@
 // admin/app.js
-import { moveArrayItem, moveObjectKey, createTextInput, createIconPicker } from './ui.js';
+import { moveArrayItem, moveObjectKey, renderGlobalSettings } from './ui.js';
 import { syncSchemaTables, renderSchemaEditor, createAddTableButton } from './schema.js';
 import { renderDashboardLayout, renderDashboardEditor, initDashboardUI } from './dashboard.js';
 import { renderCalendarEditor } from './calendar.js';
-import { renderDatabaseEditor } from './database.js'; 
-import { renderSecurityEditor } from './security.js'; 
-import { renderHealthDashboard } from './health.js';  
+import { renderDatabaseEditor } from './database.js';
+import { renderSecurityEditor } from './security.js';
+import { renderHealthDashboard } from './health.js';
 import { renderDocumentation } from './docs.js';
 import { renderUsersEditor } from './users.js';
 import { renderWorkflowsEditor } from './workflows.js';
 import { renderFilesEditor } from './files_render.js';
 
 let currentConfig = null;
-let currentFile = 'schema'; 
+let currentFile = 'schema';
 let currentItemKey = null;
 let globalSchemaObj = null;
+let isDirty = false;
 
 const itemListEl = document.getElementById('itemList');
 const workspaceEl = document.getElementById('editorForm');
 const btnSave = document.getElementById('btnSave');
 const tabs = document.querySelectorAll('.admin-tab');
+
+// Dirty-state guards: every edit marks the config dirty; navigation and reload
+// refuse to drop pending changes silently.
+export function markDirty() { isDirty = true; }
+export function markClean() { isDirty = false; }
+function confirmDiscard() {
+    return !isDirty || confirm('You have unsaved changes that will be lost. Continue?');
+}
+
+// Inline status pill — lightweight replacement for alert() after async
+// operations. The pill fades out on its own so the workflow is not blocked.
+export function showStatusPill(anchor, message, variant = 'success') {
+    if (!anchor) return;
+    const existing = anchor.parentNode && anchor.parentNode.querySelector(':scope > .status-pill');
+    if (existing) existing.remove();
+
+    const pill = document.createElement('span');
+    pill.className = 'status-pill status-pill-' + variant;
+    pill.textContent = message;
+    const colors = {
+        success: { bg: '#dcfce7', fg: '#166534', border: '#86efac' },
+        error:   { bg: '#fee2e2', fg: '#991b1b', border: '#fca5a5' },
+        info:    { bg: '#e0f2fe', fg: '#075985', border: '#7dd3fc' },
+    }[variant] || { bg: '#e2e8f0', fg: '#0f172a', border: '#cbd5e1' };
+    pill.style.cssText = `display:inline-flex; align-items:center; gap:6px; margin-left:10px; padding:4px 10px; background:${colors.bg}; color:${colors.fg}; border:1px solid ${colors.border}; border-radius:999px; font-size:12px; font-weight:600; transition:opacity .3s;`;
+    anchor.insertAdjacentElement('afterend', pill);
+
+    const ttl = variant === 'error' ? 6000 : 3000;
+    setTimeout(() => {
+        pill.style.opacity = '0';
+        setTimeout(() => pill.remove(), 300);
+    }, ttl);
+}
 
 // Utility function to escape HTML strings safely against XSS
 function escapeHtml(str) {
@@ -52,11 +86,24 @@ document.addEventListener('DOMContentLoaded', async () => {
 
     tabs.forEach(tab => {
         tab.addEventListener('click', (e) => {
+            if (!confirmDiscard()) return;
             tabs.forEach(t => t.classList.remove('active'));
-            e.currentTarget.classList.add('active'); // Poprawka z currentTarget
+            e.currentTarget.classList.add('active');
             currentFile = e.currentTarget.dataset.file;
+            markClean();
             loadConfigFile(currentFile);
         });
+    });
+
+    // Any keyboard or widget change anywhere in the workspace counts as dirty.
+    workspaceEl.addEventListener('input', markDirty);
+    workspaceEl.addEventListener('change', markDirty);
+
+    window.addEventListener('beforeunload', (e) => {
+        if (isDirty) {
+            e.preventDefault();
+            e.returnValue = '';
+        }
     });
 
     document.getElementById('btnExport').addEventListener('click', () => {
@@ -76,19 +123,22 @@ document.addEventListener('DOMContentLoaded', async () => {
         formData.append('backup_file', file);
 
         try {
-            const res = await fetch('api.php?action=import', { 
-                method: 'POST', 
+            const res = await fetch('api.php?action=import', {
+                method: 'POST',
                 headers: { 'X-CSRF-Token': getCsrfToken() },
-                body: formData 
+                body: formData
             });
             const data = await res.json();
             if (data.status === 'success') {
-                alert('Configuration imported successfully! Refreshing page...');
-                window.location.reload();
+                markClean();
+                showStatusPill(importBtn, 'Imported. Reloading…', 'success');
+                setTimeout(() => window.location.reload(), 900);
             } else {
-                alert('Import error: ' + (data.error || 'Unknown error'));
+                showStatusPill(importBtn, 'Import error: ' + (data.error || 'Unknown error'), 'error');
             }
-        } catch (err) { alert('Failed to upload file.'); }
+        } catch (err) {
+            showStatusPill(importBtn, 'Failed to upload file.', 'error');
+        }
         importInput.value = '';
     });
 });
@@ -155,7 +205,11 @@ async function loadConfigFile(fileName) {
         if (fileName === 'database' || fileName === 'security') {
             renderEditor('SETTINGS', currentConfig, false);
         }
-    } catch (err) { alert(`Failed to load ${fileName}.json`); }
+        // Freshly loaded config is clean; any subsequent edit flips the flag.
+        markClean();
+    } catch (err) {
+        showStatusPill(btnSave, `Failed to load ${fileName}.json`, 'error');
+    }
 }
 
 function addNewItem() {
@@ -172,8 +226,9 @@ function addNewItem() {
     }
     
     currentItemKey = newIndex;
+    markDirty();
     renderSidebar();
-    
+
     const items = currentFile === 'dashboard' ? currentConfig.widgets : currentFile === 'workflows' ? currentConfig.workflows : currentConfig.sources;
     renderEditor(newIndex, items[newIndex], true);
 }
@@ -185,7 +240,8 @@ function clearConfig() {
         else if (currentFile === 'calendar') currentConfig = { sources: [], menu_name: 'Calendar' };
         else if (currentFile === 'workflows') currentConfig = { workflows: [], menu_name: 'Workflows' };
         else if (currentFile === 'files') currentConfig = { menu_name: 'Files' };
-        
+
+        markDirty();
         renderSidebar();
         workspaceEl.innerHTML = `<h2>Configuration cleared. Click "Save File" to apply!</h2>`;
     }
@@ -222,12 +278,13 @@ function renderSidebar() {
     // Append the button only if the active tab is 'schema'
     if (currentFile === 'schema') {
         const btnAddTable = createAddTableButton(currentConfig, 'app', (newTableName) => {
-            alert('Table created successfully. Please click "Save File" to apply.');
-            if (typeof renderSidebar === 'function') renderSidebar(); 
+            markDirty();
+            showStatusPill(btnSave, `Table "${newTableName}" created. Remember to Save config.`, 'success');
+            renderSidebar();
         }, (err) => {
-            alert(err);
+            showStatusPill(btnSave, err, 'error');
         });
-        
+
         btnAddTable.id = 'addTableBtn';
         btnAddTable.style.fontSize = '12px';
         btnAddTable.style.float = 'right';
@@ -246,9 +303,14 @@ function renderSidebar() {
         btnSync.className = 'btn-add'; btnSync.style.width = '100%'; btnSync.innerHTML = 'Sync DB Tables';
         btnSync.onclick = () => {
             const schemaName = prompt("Enter database schema name to sync:", "public");
-            if (schemaName) syncSchemaTables(currentConfig, schemaName, 
-                (added) => { alert(`Added ${added} new tables!`); renderSidebar(); fetchGlobalSchema(); }, 
-                (err) => alert(err));
+            if (schemaName) syncSchemaTables(currentConfig, schemaName,
+                (added) => {
+                    if (added > 0) markDirty();
+                    showStatusPill(btnSync, `Added ${added} new table${added === 1 ? '' : 's'}.`, added > 0 ? 'success' : 'info');
+                    renderSidebar();
+                    fetchGlobalSchema();
+                },
+                (err) => showStatusPill(btnSync, err, 'error'));
         };
         actionDiv.appendChild(btnSync);
     } else if (currentFile !== 'files') {
@@ -312,11 +374,12 @@ function renderSidebar() {
         btnUp.innerHTML = '^'; btnUp.style.cssText = 'background:none; border:none; cursor:pointer; font-size:14px; padding:0 2px;';
         if (index === 0) { btnUp.disabled = true; btnUp.style.opacity = '0.3'; btnUp.style.cursor = 'default'; }
         btnUp.onclick = (e) => {
-            e.stopPropagation(); 
+            e.stopPropagation();
             if (isArray) {
                 moveArrayItem(itemsToIterate, key, -1);
                 if (currentItemKey === key) currentItemKey = key - 1; else if (currentItemKey === key - 1) currentItemKey = key;
             } else { currentConfig.tables = moveObjectKey(itemsToIterate, key, -1); }
+            markDirty();
             renderSidebar();
         };
 
@@ -329,6 +392,7 @@ function renderSidebar() {
                 moveArrayItem(itemsToIterate, key, 1);
                 if (currentItemKey === key) currentItemKey = key + 1; else if (currentItemKey === key + 1) currentItemKey = key;
             } else { currentConfig.tables = moveObjectKey(itemsToIterate, key, 1); }
+            markDirty();
             renderSidebar();
         };
 
@@ -361,28 +425,13 @@ function renderEditor(key, itemData, isArray) {
     if (key === 'LAYOUT') {
         if (currentFile === 'dashboard') return renderDashboardLayout(ctx);
         if (currentFile === 'calendar') {
-            workspaceEl.innerHTML = `<h3>Calendar Global Settings</h3>`;
-            workspaceEl.appendChild(createTextInput('menu_name', 'Menu Display Name', currentConfig.menu_name || 'Calendar', v => currentConfig.menu_name = v));
-            workspaceEl.appendChild(createIconPicker('menu_icon', 'Menu Icon', currentConfig.menu_icon || '', v => {
-                if (v && v.trim() !== '') currentConfig.menu_icon = v; else delete currentConfig.menu_icon;
-            }));
-            return;
+            return renderGlobalSettings(ctx, { title: 'Calendar Global Settings', defaultMenuName: 'Calendar' });
         }
         if (currentFile === 'workflows') {
-            workspaceEl.innerHTML = `<h3>Workflows Global Settings</h3>`;
-            workspaceEl.appendChild(createTextInput('menu_name', 'Menu Display Name', currentConfig.menu_name || 'Workflows', v => currentConfig.menu_name = v));
-            workspaceEl.appendChild(createIconPicker('menu_icon', 'Menu Icon', currentConfig.menu_icon || '', v => {
-                if (v && v.trim() !== '') currentConfig.menu_icon = v; else delete currentConfig.menu_icon;
-            }));
-            return;
+            return renderGlobalSettings(ctx, { title: 'Workflows Global Settings', defaultMenuName: 'Workflows' });
         }
         if (currentFile === 'files') {
-            workspaceEl.innerHTML = `<h3>Files Global Settings</h3>`;
-            workspaceEl.appendChild(createTextInput('menu_name', 'Menu Display Name', currentConfig.menu_name || 'Files', v => currentConfig.menu_name = v));
-            workspaceEl.appendChild(createIconPicker('menu_icon', 'Menu Icon', currentConfig.menu_icon || '', v => {
-                if (v && v.trim() !== '') currentConfig.menu_icon = v; else delete currentConfig.menu_icon;
-            }));
-            return;
+            return renderGlobalSettings(ctx, { title: 'Files Global Settings', defaultMenuName: 'Files' });
         }
     }
     
@@ -401,7 +450,8 @@ function renderEditor(key, itemData, isArray) {
             if (currentFile === 'dashboard') currentConfig.widgets.splice(key, 1);
             else if (currentFile === 'workflows') currentConfig.workflows.splice(key, 1);
             else currentConfig.sources.splice(key, 1);
-            currentItemKey = null; 
+            currentItemKey = null;
+            markDirty();
             workspaceEl.innerHTML = '<h2>Item deleted. Save file to apply.</h2>';
             renderSidebar();
         }
@@ -418,20 +468,23 @@ btnSave.addEventListener('click', async () => {
     if (!currentConfig) return;
     try {
         const response = await fetch(`api.php?action=save&file=${currentFile}`, {
-            method: 'POST', 
-            headers: { 
+            method: 'POST',
+            headers: {
                 'Content-Type': 'application/json',
                 'X-CSRF-Token': getCsrfToken()
-            }, 
+            },
             body: JSON.stringify(currentConfig)
         });
         const result = await response.json();
-        
-        if (result.status === 'success') { 
-            alert(`${currentFile}.json saved!`); 
-            fetchGlobalSchema(); 
+
+        if (result.status === 'success') {
+            markClean();
+            showStatusPill(btnSave, `${currentFile}.json saved`, 'success');
+            fetchGlobalSchema();
         } else {
-            alert('Error saving: ' + (result.error || 'Unknown error'));
+            showStatusPill(btnSave, 'Error saving: ' + (result.error || 'Unknown error'), 'error');
         }
-    } catch (err) { alert('Failed to save changes.'); }
+    } catch (err) {
+        showStatusPill(btnSave, 'Failed to save changes.', 'error');
+    }
 });

--- a/admin/dashboard.js
+++ b/admin/dashboard.js
@@ -1,5 +1,5 @@
 // admin/dashboard.js
-import { createTextInput, createSelectInput, createColorInput, createIconPicker } from './ui.js';
+import { createTextInput, createSelectInput, createColorInput, createIconPicker, createCheckbox, renderGlobalSettings } from './ui.js';
 
 // Added new widget types for vertical bar and pie charts
 export const WIDGET_TYPES = [
@@ -17,22 +17,20 @@ export function initDashboardUI() {
 }
 
 export function renderDashboardLayout(ctx) {
-    const { workspaceEl, currentConfig } = ctx;
-    workspaceEl.innerHTML = '<h3>Dashboard Global Settings</h3>';
-    
-    workspaceEl.appendChild(createTextInput('menu_name', 'Menu Display Name', currentConfig.menu_name || 'Dashboard', v => currentConfig.menu_name = v));
-    workspaceEl.appendChild(createIconPicker('menu_icon', 'Menu Icon', currentConfig.menu_icon || '', v => {
-        if (v && v.trim() !== '') currentConfig.menu_icon = v;
-        else delete currentConfig.menu_icon;
-    }));
+    renderGlobalSettings(ctx, {
+        title: 'Dashboard Global Settings',
+        defaultMenuName: 'Dashboard',
+        includeHidden: true,
+        onAfter: ({ workspaceEl, currentConfig }) => {
+            const layoutTitle = document.createElement('h4');
+            layoutTitle.textContent = 'Grid Layout (CSS)';
+            layoutTitle.style.marginTop = '20px';
+            workspaceEl.appendChild(layoutTitle);
 
-    const layoutTitle = document.createElement('h4');
-    layoutTitle.textContent = 'Grid Layout (CSS)';
-    layoutTitle.style.marginTop = '20px';
-    workspaceEl.appendChild(layoutTitle);
-
-    workspaceEl.appendChild(createTextInput('layout_cols', 'Grid Columns (CSS)', currentConfig.layout.columns, v => currentConfig.layout.columns = v));
-    workspaceEl.appendChild(createTextInput('layout_gap', 'Grid Gap (CSS)', currentConfig.layout.gap, v => currentConfig.layout.gap = v));
+            workspaceEl.appendChild(createTextInput('layout_cols', 'Grid Columns (CSS)', currentConfig.layout.columns, v => currentConfig.layout.columns = v));
+            workspaceEl.appendChild(createTextInput('layout_gap', 'Grid Gap (CSS)', currentConfig.layout.gap, v => currentConfig.layout.gap = v));
+        },
+    });
 }
 
 export function renderDashboardEditor(key, itemData, isArray, ctx) {

--- a/admin/docs.js
+++ b/admin/docs.js
@@ -65,7 +65,7 @@ export function renderDocumentation(ctx) {
                         <li><strong>Phone (9-15 digits, optional +):</strong> <code>^\+?[0-9]{9,15}$</code></li>
                         <li><strong>Postal code (XX-XXX):</strong> <code>^[0-9]{2}-[0-9]{3}$</code></li>
                         <li><strong>URL (http/https):</strong> <code>^https?:\/\/.*$</code></li>
-                        <li><strong>Username (3-16 chars, letters/digits/underscore):</strong> <code>^[a-zA-Z0-9_]{3,16}$</code></li>
+                        <li><strong>Username (3-16 chars, letters/digits/_ ):</strong> <code>^[a-zA-Z0-9_]{3,16}$</code></li>
                         <li><strong>Price / decimal (up to 2 places):</strong> <code>^\d+(\.\d{1,2})?$</code></li>
                         <li><strong>Date (YYYY-MM-DD):</strong> <code>^\d{4}-\d{2}-\d{2}$</code></li>
                         <li><strong>Time (HH:MM, 24h):</strong> <code>^([01]\\d|2[0-3]):[0-5]\\d$</code></li>
@@ -166,7 +166,7 @@ export function renderDocumentation(ctx) {
             <ul style="padding-left: 20px;">
                 <li><strong>Deny public access to <code>includes/</code>:</strong> Configure your web server so <code>database.json</code>, <code>security.json</code> and <code>schema.json</code> cannot be fetched directly.</li>
                 <li><strong>Environment variables:</strong> <code>PGHOST</code>, <code>PGPORT</code>, <code>PGDATABASE</code>, <code>PGUSER</code>, <code>PGPASSWORD</code>, <code>PGSCHEMA</code>. <code>PGSCHEMA</code> is the fallback for the system schema when <code>database.json</code> does not define <code>schema</code>.</li>
-                <li><strong>Storage permissions:</strong> Under Docker, <code>includes/</code> and <code>storage/</code> must be writable by the web-server user (UID/GID <code>82:82</code> for Alpine-based images).</li>
+                <li><strong>Storage permissions:</strong> Under Docker, <code>includes/</code> and <code>storage/</code> must be writable by the web-server user (UID/GID <code>82:82</code> for musl-based slim PHP images).</li>
                 <li><strong>Backups:</strong> Export the config ZIP before every upgrade and keep regular <code>pg_dump</code> snapshots of both application and <code>spw_*</code> tables.</li>
             </ul>
         </div>

--- a/admin/docs.js
+++ b/admin/docs.js
@@ -19,7 +19,8 @@ export function renderDocumentation(ctx) {
                 <li><strong>Main tabs:</strong> Schema, Dashboard, Calendar, Workflows, Files.</li>
                 <li><strong>System drop-down:</strong> Database, Security, Users, System Health.</li>
                 <li><strong>Configuration drop-down:</strong> Export / Import the entire configuration as a ZIP archive (recommended before every production deployment).</li>
-                <li><strong>Save config:</strong> Persists the currently edited JSON file to <code>includes/</code>. You must click it before switching tabs or testing the database connection.</li>
+                <li><strong>Save config:</strong> Persists the currently edited JSON file to <code>includes/</code>. After a successful save a green status pill appears next to the button confirming which file was written. Error pills stay visible for 6 seconds so they are not missed.</li>
+                <li><strong>Unsaved-changes guard:</strong> The admin panel tracks whether any field has been modified since the last save. Switching to a different tab while there are pending changes shows a confirmation prompt so edits are not silently discarded. The browser also intercepts page reloads and closures when changes are pending.</li>
                 <li><strong>Debug FE mode:</strong> Toggle in the header. When enabled, the frontend exposes a <code>#debug</code> panel with raw payloads for schema/API responses — useful when building new tables or troubleshooting grids.</li>
                 <li><strong>Docs icon (book):</strong> Opens this documentation page.</li>
             </ul>
@@ -53,6 +54,7 @@ export function renderDocumentation(ctx) {
                 <li><strong>Add new tables:</strong> Use <em>+ Add Table</em> to create new physical tables in PostgreSQL. You specify the schema and table name; the system automatically creates the mandatory <code>id</code> primary key.</li>
                 <li><strong>Add new columns:</strong> Inside a table's configuration, click <em>+ Add Column</em> to append a physical column to the database. Specify name and native SQL type (e.g. <code>varchar(255)</code>, <code>boolean</code>, <code>int4</code>).</li>
                 <li><strong>Sync DB Tables:</strong> Fetches all tables and columns from the connected database and merges them into your schema configuration. System tables with the <code>spw_</code> prefix are skipped automatically.</li>
+                <li><strong>Live sidebar preview:</strong> When editing a table's Display Name, Icon or the <em>Hide from Sidebar Menu</em> flag, a small dark preview strip updates in real time showing exactly how the entry will appear in the frontend navigation — including the icon image, the display name, and a red <em>HIDDEN</em> badge when the table is hidden.</li>
                 <li><strong>Smart type mapping:</strong> Native PostgreSQL types (<code>int4</code>, <code>varchar</code>, <code>boolean</code>, etc.) are mapped to clean frontend types (Text, Number, Date, Boolean, Enum). You can override the mapping with the provided dropdowns.</li>
                 <li><strong>Remove tables:</strong> The red <em>Delete Table</em> button removes a table from your JSON configuration <strong>only</strong> — it does not drop the physical table from PostgreSQL.</li>
                 <li><strong>Foreign-key search &amp; display:</strong> Assign multiple display columns to a foreign key (e.g. <code>first_name, last_name</code>). The frontend grid renders them as searchable inputs — practical across thousands of records.</li>
@@ -84,7 +86,7 @@ export function renderDocumentation(ctx) {
             <h3 style="color: #2563eb; margin-top: 30px;">3. Dashboard Builder</h3>
             <p>The <strong>Dashboard</strong> tab composes analytical views from your database.</p>
             <ul style="padding-left: 20px;">
-                <li><strong>Global settings:</strong> Define the main layout grid using CSS grid properties (e.g. <code>repeat(auto-fit, minmax(300px, 1fr))</code>).</li>
+                <li><strong>Global settings:</strong> Define the menu name, icon, visibility and the main layout grid (CSS grid properties, e.g. <code>repeat(auto-fit, minmax(300px, 1fr))</code>). A live sidebar preview updates as you type so you can see the final menu entry before saving.</li>
                 <li><strong>Stat cards:</strong> Simple metric widgets showing the total row count of a selected table.</li>
                 <li><strong>KPI cards:</strong> Single aggregate numbers based on specific columns (COUNT, SUM, AVG, MIN, MAX).</li>
                 <li><strong>Bar charts:</strong> Group by X-axis column and aggregate on the Y-axis column.</li>
@@ -103,6 +105,7 @@ export function renderDocumentation(ctx) {
             <h3 style="color: #2563eb; margin-top: 30px;">4. Calendar Module</h3>
             <p>The <strong>Calendar</strong> tab binds date columns from your database directly to a visual calendar.</p>
             <ul style="padding-left: 20px;">
+                <li><strong>Global settings:</strong> The <em>Global Settings</em> sidebar item lets you set the menu name, icon and visibility of the Calendar entry in the frontend navigation. A live sidebar preview reflects changes immediately.</li>
                 <li><strong>Data sources:</strong> Overlay multiple tables on a single calendar. For each source select the table, the date column and the title column.</li>
                 <li><strong>Color coding:</strong> Assign a color per source to distinguish events at a glance.</li>
                 <li><strong>Row context:</strong> The full database row is attached to each calendar event, enabling click-through modals or custom actions.</li>
@@ -111,7 +114,7 @@ export function renderDocumentation(ctx) {
             <h3 style="color: #2563eb; margin-top: 30px;">5. Workflows Builder</h3>
             <p>The <strong>Workflows</strong> tab composes multi-step wizards that guide users through structured data entry across related tables.</p>
             <ul style="padding-left: 20px;">
-                <li><strong>Global settings:</strong> Click the root <code>workflows.json</code> item to set the main menu name and menu icon for the frontend.</li>
+                <li><strong>Global settings:</strong> Click <em>Global Settings</em> in the sidebar to set the menu name, icon and visibility of the Workflows entry. A live sidebar preview shows the result immediately, including a <em>HIDDEN</em> badge when the section is hidden.</li>
                 <li><strong>Workflow details:</strong> Each workflow requires Title, short description and icon — rendered as a card in the frontend workflows grid.</li>
                 <li><strong>Steps setup:</strong> Add sequential steps and select a target table per step. Each step can have its own description.</li>
                 <li><strong>Relational linking:</strong> Link child records to parents by selecting the foreign-key column in the current step and mapping it to a previously completed step.</li>
@@ -153,6 +156,7 @@ export function renderDocumentation(ctx) {
             <h3 style="color: #2563eb; margin-top: 30px;">9. Files Module</h3>
             <p>The <strong>Files</strong> tab is a central repository for documents and media, backed by the <code>spw_files</code> table.</p>
             <ul style="padding-left: 20px;">
+                <li><strong>Global settings:</strong> The <em>Global Settings</em> sidebar item lets you set the menu name, icon and visibility of the Files entry. A live sidebar preview updates as you change these values.</li>
                 <li><strong>Configuration:</strong> Set maximum file size (MB), allowed file types (images, PDFs, docs, spreadsheets, archives) and the storage path. The storage path must <strong>not</strong> be web-accessible — downloads are streamed through <code>file_download.php</code>.</li>
                 <li><strong>Record relations:</strong> Optionally link uploads to specific rows in a target table, so files appear attached to business records (e.g. contracts on a client).</li>
                 <li><strong>File library:</strong> Upload, search, filter by type, preview images and delete files from the admin UI. Deletions are logged to the audit trail.</li>

--- a/admin/schema.js
+++ b/admin/schema.js
@@ -1,5 +1,6 @@
 // admin/schema.js
-import { createTextInput, createSelectInput, createCheckbox, createColorInput, createIconPicker, moveObjectKey } from './ui.js';
+import { createTextInput, createSelectInput, createCheckbox, createColorInput, createIconPicker, moveObjectKey, createMenuPreview } from './ui.js';
+import { showStatusPill, markDirty } from './app.js';
 
 // Utility function to escape HTML strings safely against XSS
 function escapeHtml(str) {
@@ -18,7 +19,7 @@ export function createAddTableButton(currentConfig, defaultSchema, onSuccess, on
 
     btnAddTable.onclick = async (e) => {
         e.preventDefault();
-        
+
         const tableName = prompt('Enter new table name (lowercase, no spaces):');
         if (!tableName) return;
 
@@ -27,7 +28,7 @@ export function createAddTableButton(currentConfig, defaultSchema, onSuccess, on
 
         // Prevent duplicates
         if (currentConfig.tables && currentConfig.tables[formattedName]) {
-            alert('Table already exists in configuration.');
+            onError('Table already exists in configuration.');
             return;
         }
 
@@ -140,10 +141,9 @@ export function renderSchemaEditor(tableName, tableData, ctx) {
             }
             workspaceEl.innerHTML = '<h3 style="color: #ef4444;">Table removed from configuration. Please click "Save File" to apply changes.</h3>';
             
+            markDirty();
             if (typeof ctx.renderSidebar === 'function') {
                 ctx.renderSidebar();
-            } else {
-                alert('Table removed. Please save the file and refresh the page to update the sidebar.');
             }
         }
     };
@@ -178,21 +178,22 @@ export function renderSchemaEditor(tableName, tableData, ctx) {
             });
 
             const rawText = await res.text();
-            
+
             if (!res.ok) {
-                alert("HTTP Error " + res.status + ":\n" + rawText);
+                showStatusPill(btnSyncCols, `HTTP Error ${res.status}`, 'error');
+                console.error('Sync columns HTTP error:', res.status, rawText);
                 return;
             }
-            
+
             let data;
             try {
                 data = JSON.parse(rawText);
             } catch (parseErr) {
-                alert("Server returned PHP error instead of JSON:\n\n" + rawText);
-                console.error("RAW RESPONSE:", rawText);
+                showStatusPill(btnSyncCols, 'Server returned invalid JSON. Check console.', 'error');
+                console.error('RAW RESPONSE:', rawText);
                 return;
             }
-            
+
             if (data.status === 'success') {
                 let added = 0;
                 data.columns.forEach(col => {
@@ -231,14 +232,15 @@ export function renderSchemaEditor(tableName, tableData, ctx) {
                         added++;
                     }
                 });
-                alert(`Added ${added} new columns.`);
+                if (added > 0) markDirty();
+                showStatusPill(btnSyncCols, `Added ${added} new column${added === 1 ? '' : 's'}.`, added > 0 ? 'success' : 'info');
                 renderEditor(tableName, tableData, false);
             } else {
-                alert("API Error:\n" + (data.error || 'Failed to sync columns.'));
+                showStatusPill(btnSyncCols, 'API Error: ' + (data.error || 'Failed to sync columns.'), 'error');
             }
         } catch (err) {
             console.error(err);
-            alert('Communication error. Check console.');
+            showStatusPill(btnSyncCols, 'Communication error. Check console.', 'error');
         }
     };
     workspaceEl.appendChild(btnSyncCols);
@@ -253,7 +255,7 @@ export function renderSchemaEditor(tableName, tableData, ctx) {
 
     btnAddCol.onclick = async (e) => {
         e.preventDefault();
-        
+
         const colName = prompt('Enter new column name (lowercase, no spaces):');
         if (!colName) return;
 
@@ -262,7 +264,7 @@ export function renderSchemaEditor(tableName, tableData, ctx) {
 
         // Prevent duplicates
         if (tableData.columns && tableData.columns[formattedColName]) {
-            alert('Column already exists.');
+            showStatusPill(btnAddCol, 'Column already exists.', 'error');
             return;
         }
 
@@ -282,30 +284,50 @@ export function renderSchemaEditor(tableName, tableData, ctx) {
 
             const result = await response.json();
             if (result.status === 'success') {
-                // Update configuration object in memory
                 tableData.columns[formattedColName] = {
                     display_name: formattedColName.replace(/_/g, ' ').charAt(0).toUpperCase() + formattedColName.replace(/_/g, ' ').slice(1),
                     type: 'text'
                 };
-                
-                // Re-render the schema editor view
+                markDirty();
                 renderEditor(tableName, tableData, false);
             } else {
-                alert('Error adding column: ' + result.error);
+                showStatusPill(btnAddCol, 'Error adding column: ' + result.error, 'error');
             }
         } catch (err) {
             console.error(err);
-            alert('Network error occurred.');
+            showStatusPill(btnAddCol, 'Network error occurred.', 'error');
         }
     };
     workspaceEl.appendChild(btnAddCol);
 
-    workspaceEl.appendChild(createTextInput('display_name', 'Display Name', tableData.display_name, (val) => tableData.display_name = val));
+    // Live FE sidebar preview — mirrors the menu entry produced by this table
+    // in templates/menu.php so changes to display_name/icon/hidden are visible
+    // immediately without saving.
+    const preview = createMenuPreview();
+    workspaceEl.appendChild(preview.el);
+    const refreshPreview = () => preview.update({
+        name: tableData.display_name || tableName,
+        icon: tableData.icon || '',
+        hidden: !!tableData.hidden,
+    });
+    refreshPreview();
+
+    workspaceEl.appendChild(createTextInput('display_name', 'Display Name', tableData.display_name, (val) => {
+        tableData.display_name = val;
+        refreshPreview();
+    }));
     workspaceEl.appendChild(createTextInput('schema', 'Database Schema', tableData.schema || 'app', (val) => tableData.schema = val));
-    
-    workspaceEl.appendChild(createIconPicker('icon', 'Icon Path', tableData.icon, (val) => { if(val) tableData.icon = val; else delete tableData.icon; }));
-    
-    workspaceEl.appendChild(createCheckbox('hidden', 'Hide from Sidebar Menu', tableData.hidden, (val) => tableData.hidden = val, false));
+
+    workspaceEl.appendChild(createIconPicker('icon', 'Icon Path', tableData.icon, (val) => {
+        if (val) tableData.icon = val;
+        else delete tableData.icon;
+        refreshPreview();
+    }));
+
+    workspaceEl.appendChild(createCheckbox('hidden', 'Hide from Sidebar Menu', tableData.hidden, (val) => {
+        tableData.hidden = val;
+        refreshPreview();
+    }, false));
 
     const colsTitle = document.createElement('h3');
     colsTitle.textContent = 'Columns Configuration';

--- a/admin/ui.js
+++ b/admin/ui.js
@@ -223,6 +223,111 @@ export function createCheckbox(key, labelText, value, onChange, defaultValue = t
     return container;
 }
 
+// Small visual preview that mirrors how a menu item will be rendered in the FE
+// sidebar. Kept in-sync with templates/menu.php semantics (image when the value
+// looks like a path, text glyph otherwise, dimmed when hidden).
+export function createMenuPreview() {
+    const wrapper = document.createElement('div');
+    wrapper.className = 'form-group menu-preview';
+
+    const label = document.createElement('label');
+    label.textContent = 'Live sidebar preview';
+    wrapper.appendChild(label);
+
+    const item = document.createElement('div');
+    item.className = 'menu-preview-item';
+    item.style.cssText = 'display:flex; align-items:center; gap:10px; padding:10px 14px; background:#0f172a; color:#e2e8f0; border-radius:6px; font-size:14px; min-width:220px; max-width:320px; transition:opacity .15s;';
+
+    const iconEl = document.createElement('span');
+    iconEl.style.cssText = 'width:20px; height:20px; display:inline-flex; align-items:center; justify-content:center; flex-shrink:0;';
+
+    const nameEl = document.createElement('span');
+    nameEl.style.cssText = 'flex:1; white-space:nowrap; overflow:hidden; text-overflow:ellipsis;';
+
+    const badgeEl = document.createElement('span');
+    badgeEl.textContent = 'HIDDEN';
+    badgeEl.style.cssText = 'font-size:10px; background:#ef4444; color:#fff; padding:2px 6px; border-radius:3px; display:none; letter-spacing:.5px;';
+
+    item.appendChild(iconEl);
+    item.appendChild(nameEl);
+    item.appendChild(badgeEl);
+    wrapper.appendChild(item);
+
+    const update = ({ name, icon, hidden }) => {
+        nameEl.textContent = name || '';
+        iconEl.innerHTML = '';
+        if (icon) {
+            const looksLikePath = icon.includes('/') || icon.includes('.');
+            if (looksLikePath) {
+                const img = document.createElement('img');
+                img.src = '../' + icon;
+                img.alt = '';
+                img.style.cssText = 'max-width:20px; max-height:20px; filter:brightness(0) invert(1);';
+                img.onerror = () => { iconEl.innerHTML = ''; iconEl.textContent = '?'; };
+                iconEl.appendChild(img);
+            } else {
+                iconEl.textContent = icon;
+            }
+        }
+        item.style.opacity = hidden ? '0.4' : '1';
+        badgeEl.style.display = hidden ? 'inline-block' : 'none';
+    };
+
+    return { el: wrapper, update };
+}
+
+// Shared renderer for per-section global menu settings (Dashboard/Calendar/
+// Workflows/Files). Replaces four near-identical copies and keeps the live
+// sidebar preview consistent across sections.
+export function renderGlobalSettings(ctx, options = {}) {
+    const { workspaceEl, currentConfig } = ctx;
+    const {
+        title = 'Global Settings',
+        defaultMenuName = '',
+        includeHidden = true,
+        onAfter,
+    } = options;
+
+    workspaceEl.innerHTML = '';
+    const heading = document.createElement('h3');
+    heading.textContent = title;
+    workspaceEl.appendChild(heading);
+
+    const preview = createMenuPreview();
+    workspaceEl.appendChild(preview.el);
+
+    const refreshPreview = () => preview.update({
+        name: currentConfig.menu_name || defaultMenuName,
+        icon: currentConfig.menu_icon || '',
+        hidden: !!currentConfig.hidden,
+    });
+    refreshPreview();
+
+    workspaceEl.appendChild(createTextInput('menu_name', 'Menu Display Name',
+        currentConfig.menu_name || defaultMenuName, v => {
+            currentConfig.menu_name = v;
+            refreshPreview();
+        }));
+
+    workspaceEl.appendChild(createIconPicker('menu_icon', 'Menu Icon',
+        currentConfig.menu_icon || '', v => {
+            if (v && v.trim() !== '') currentConfig.menu_icon = v;
+            else delete currentConfig.menu_icon;
+            refreshPreview();
+        }));
+
+    if (includeHidden) {
+        workspaceEl.appendChild(createCheckbox('hidden', 'Hide from Sidebar Menu',
+            currentConfig.hidden, v => {
+                if (v) currentConfig.hidden = true;
+                else delete currentConfig.hidden;
+                refreshPreview();
+            }, false));
+    }
+
+    if (typeof onAfter === 'function') onAfter(ctx);
+}
+
 // New function to handle multiple choices via checkboxes list
 export function createMultiSelect(key, labelText, options, selectedValues, onChange) {
     const wrapper = document.createElement('div');

--- a/admin/workflows.js
+++ b/admin/workflows.js
@@ -1,17 +1,11 @@
 // admin/workflows.js
 import { createTextInput, createSelectInput, createIconPicker } from './ui.js';
 
-// Render the multi-step wizard configuration interface
+// Render the multi-step wizard configuration interface. Global Workflow
+// settings (menu_name/menu_icon/hidden) are handled centrally in app.js via
+// the shared renderGlobalSettings helper.
 export function renderWorkflowsEditor(key, itemData, isArray, ctx) {
     const { workspaceEl, getTableOptions, getColumnOptionsForTable, renderEditor } = ctx;
-
-    // Check if editing the global root configuration object
-    if (itemData.workflows !== undefined) {
-        workspaceEl.innerHTML = '<h3>Global Workflow Settings</h3>';
-        workspaceEl.appendChild(createTextInput('menu_name', 'Menu Name', itemData.menu_name || 'Workflows', v => itemData.menu_name = v));
-        workspaceEl.appendChild(createIconPicker('menu_icon', 'Menu Icon', itemData.menu_icon || '', v => itemData.menu_icon = v));
-        return;
-    }
 
     // Ensure array structure for workflow steps
     if (!itemData.steps) itemData.steps = [];

--- a/api.php
+++ b/api.php
@@ -81,6 +81,7 @@ try {
         $response = [
             'menu_name' => $dashboard['menu_name'] ?? 'Dashboard',
             'menu_icon' => $dashboard['menu_icon'] ?? '',
+            'hidden' => !empty($dashboard['hidden']),
             'layout' => $dashboard['layout'] ?? [],
             'widgets' => []
         ];
@@ -307,6 +308,7 @@ try {
         echo json_encode([
             'menu_name' => $calendar['menu_name'] ?? 'Calendar',
             'menu_icon' => $calendar['menu_icon'] ?? '',
+            'hidden' => !empty($calendar['hidden']),
             'events' => $events
         ]);
         exit;

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -67,8 +67,10 @@ document.addEventListener('DOMContentLoaded', async () => {
             
             let dashName = 'Dashboard';
             let dashIconEl = renderIconElement('', 'assets/icons/dashboard.png');
+            let dashHidden = false;
             let calName = 'Calendar';
             let calIconEl = renderIconElement('', 'assets/icons/calendar.png');
+            let calHidden = false;
             let filesName = 'Files';
             let filesIconEl = renderIconElement('', 'assets/icons/folder_open.png');
 
@@ -78,6 +80,7 @@ document.addEventListener('DOMContentLoaded', async () => {
                     const dashCfg = await dashRes.json();
                     if (dashCfg.menu_name) dashName = dashCfg.menu_name;
                     dashIconEl = renderIconElement(dashCfg.menu_icon, 'assets/icons/dashboard.png');
+                    dashHidden = dashCfg.hidden === true;
                 }
             } catch(e) { console.warn('Could not load dashboard config', e); }
 
@@ -87,6 +90,7 @@ document.addEventListener('DOMContentLoaded', async () => {
                     const calCfg = await calRes.json();
                     if (calCfg.menu_name) calName = calCfg.menu_name;
                     calIconEl = renderIconElement(calCfg.menu_icon, 'assets/icons/calendar.png');
+                    calHidden = calCfg.hidden === true;
                 }
             } catch(e) { console.warn('Could not load calendar config', e); }
 
@@ -154,14 +158,15 @@ document.addEventListener('DOMContentLoaded', async () => {
             filesItem.appendChild(filesLink);
 
             // Prepend in reverse order to achieve: Dashboard, Calendar, Files
+            // Skip modules flagged as hidden in their Global Settings
             if (navList.tagName === 'UL') {
                 navList.prepend(filesItem);
-                navList.prepend(calItem);
-                navList.prepend(dashItem);
+                if (!calHidden) navList.prepend(calItem);
+                if (!dashHidden) navList.prepend(dashItem);
             } else {
                 menuEl.prepend(filesLink);
-                menuEl.prepend(calLink);
-                menuEl.prepend(dashLink);
+                if (!calHidden) menuEl.prepend(calLink);
+                if (!dashHidden) menuEl.prepend(dashLink);
             }
             
             // Dynamically create a container for Active Filter Pills

--- a/assets/js/workflows.js
+++ b/assets/js/workflows.js
@@ -34,8 +34,13 @@ function createIconElement(iconPath, fallbackColor = 'var(--accent)') {
 // Main initialization function to be called from app.js
 export async function initWorkflows(menuListEl, containerEl, titleEl, appSchema) {
     const config = await fetchWorkflowsConfig();
-    
+
     if (!config || !config.workflows || config.workflows.length === 0) {
+        return;
+    }
+
+    // Respect the "Hide from Sidebar Menu" flag from admin Global Settings
+    if (config.hidden === true) {
         return;
     }
 

--- a/login.php
+++ b/login.php
@@ -11,6 +11,37 @@ session_set_cookie_params([
 
 session_start();
 
+// Resolve the landing page after login by walking the sidebar order.
+// When an administrator hides a module from the sidebar (hidden: true in
+// the matching JSON config), we skip it so the user lands on the first
+// item that is actually visible in the navigation. Order mirrors the
+// prepend sequence in assets/js/app.js: Dashboard, Calendar, Files,
+// then the first table in the schema.
+function resolve_landing_page(): string {
+    $isHidden = static function (string $configFile): bool {
+        $path = __DIR__ . '/includes/' . $configFile;
+        if (!is_file($path)) {
+            return false;
+        }
+        $raw = @file_get_contents($path);
+        if ($raw === false) {
+            return false;
+        }
+        $cfg = json_decode($raw, true);
+        return is_array($cfg) && !empty($cfg['hidden']);
+    };
+
+    if (!$isHidden('dashboard.json')) {
+        return 'dashboard.php';
+    }
+    if (!$isHidden('calendar.json')) {
+        return 'calendar.php';
+    }
+    // Files module is always visible; index.php renders the first
+    // non-hidden table for any remaining case.
+    return 'index.php';
+}
+
 // Generate a unique nonce for Content Security Policy
 $cspNonce = bin2hex(random_bytes(16));
 
@@ -22,7 +53,7 @@ header("Content-Security-Policy: default-src 'self'; style-src 'self' 'nonce-$cs
 
 // Redirect if already authenticated
 if (isset($_SESSION['user_id'])) {
-    header("Location: dashboard.php");
+    header("Location: " . resolve_landing_page());
     exit;
 }
 
@@ -118,7 +149,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 
                     log_user_action($conn, $user['id'], 'LOGIN');
 
-                    header("Location: dashboard.php");
+                    header("Location: " . resolve_landing_page());
                     exit;
                 } else {
                     // Log failed attempt


### PR DESCRIPTION
- Add isDirty flag + beforeunload to prevent silent data loss on tab switch or reload
- Replace all alert() calls with auto-dismissing status pills (showStatusPill)
- Extract renderGlobalSettings(ctx) helper in ui.js; remove 3 duplicate blocks from app.js and dashboard.js; add hidden checkbox to Files for consistency
- Remove dead itemData.workflows branch from workflows.js
- Add admin_db_fail() in admin/api.php: log raw pg_last_error() server-side, return generic message to client (9 sites patched)
- Add createMenuPreview() in ui.js: live FE sidebar preview in all global settings sections and per-table schema editor