### PR TITLE
Add ad-hoc Run Notifications Cron and fix notification list rendering

### DIFF
--- a/admin/api.php
+++ b/admin/api.php
@@ -36,11 +36,30 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 }
 
 // Ensure state-changing actions use POST method to prevent CSRF via GET
-$postActions = ['save', 'import', 'init_db', 'users_add', 'users_toggle', 'users_update_role', 'create_table', 'add_column'];
+$postActions = ['save', 'import', 'init_db', 'users_add', 'users_toggle', 'users_update_role', 'create_table', 'add_column', 'run_cron_notifications'];
 if (in_array($action, $postActions, true) && $_SERVER['REQUEST_METHOD'] !== 'POST') {
     header('Content-Type: application/json');
     http_response_code(405);
     echo json_encode(['status' => 'error', 'error' => 'Method Not Allowed. Use POST.']);
+    exit;
+}
+
+// Run cron_notifications.php ad-hoc and return captured output
+if ($action === 'run_cron_notifications') {
+    header('Content-Type: application/json');
+    $cronScript = realpath(__DIR__ . '/../cron/cron_notifications.php');
+    if ($cronScript === false || !is_readable($cronScript)) {
+        echo json_encode(['status' => 'error', 'error' => 'Cron script not found.']);
+        exit;
+    }
+    if (!function_exists('exec')) {
+        echo json_encode(['status' => 'error', 'error' => 'exec() is disabled on this server.']);
+        exit;
+    }
+    $lines = [];
+    $returnCode = 0;
+    exec(PHP_BINARY . ' ' . escapeshellarg($cronScript) . ' admin 2>&1', $lines, $returnCode);
+    echo json_encode(['status' => 'success', 'output' => implode("\n", $lines)]);
     exit;
 }
 
@@ -54,6 +73,7 @@ if ($action === 'init_db') {
         $tUsers = sys_table('users');
         $tUsersLog = sys_table('users_log');
         $tUsersNotifications = sys_table('users_notifications');
+        $tCronLog = sys_table('users_notifications_log');
         $tFiles = sys_table('files');
         $tLoginAttempts = sys_table('login_attempts');
 
@@ -75,6 +95,8 @@ if ($action === 'init_db') {
             "CREATE TABLE IF NOT EXISTS $tLoginAttempts ( id serial4 NOT NULL, username varchar(50) NOT NULL, ip_hash varchar(64) NOT NULL, attempted_at timestamp DEFAULT CURRENT_TIMESTAMP NOT NULL, CONSTRAINT spw_login_attempts_pkey PRIMARY KEY (id) )",
             "CREATE INDEX IF NOT EXISTS idx_spw_login_attempts_username ON $tLoginAttempts USING btree (username, attempted_at)",
             "CREATE INDEX IF NOT EXISTS idx_spw_login_attempts_ip ON $tLoginAttempts USING btree (ip_hash, attempted_at)",
+            "CREATE TABLE IF NOT EXISTS $tCronLog ( id serial4 NOT NULL, started_at timestamp DEFAULT CURRENT_TIMESTAMP NOT NULL, finished_at timestamp NULL, status varchar(20) NOT NULL DEFAULT 'running', triggered_by varchar(20) NOT NULL DEFAULT 'cron', sources_processed int4 NULL, notifications_created int4 NULL, error_message text NULL, CONSTRAINT spw_users_notifications_log_pkey PRIMARY KEY (id) )",
+            "CREATE INDEX IF NOT EXISTS idx_spw_cron_log_started_at ON $tCronLog USING btree (started_at)",
             "INSERT INTO $tUsers (username, password_hash, is_active, role) SELECT 'test', '\$2y\$12\$oqxkKJu53qLCJSnmyxs1BeIDeP81M.cstuhm7T6hS0HPMXYqaK2Je', true, 'full' WHERE NOT EXISTS (SELECT 1 FROM $tUsers WHERE username = 'test')"
         ];
         

--- a/admin/app.js
+++ b/admin/app.js
@@ -106,6 +106,46 @@ document.addEventListener('DOMContentLoaded', async () => {
         }
     });
 
+    document.getElementById('btnRunCron').addEventListener('click', async () => {
+        const overlay = document.createElement('div');
+        overlay.style.cssText = 'position:fixed;inset:0;background:rgba(0,0,0,.5);z-index:9999;display:flex;align-items:center;justify-content:center;';
+        const box = document.createElement('div');
+        box.style.cssText = 'background:#fff;border-radius:8px;padding:24px;width:680px;max-width:95vw;max-height:80vh;display:flex;flex-direction:column;gap:12px;';
+        const header = document.createElement('div');
+        header.style.cssText = 'display:flex;align-items:center;justify-content:space-between;';
+        const title = document.createElement('strong');
+        title.textContent = 'Run Notifications Cron';
+        const closeBtn = document.createElement('button');
+        closeBtn.textContent = '✕';
+        closeBtn.style.cssText = 'background:none;border:none;font-size:18px;cursor:pointer;line-height:1;';
+        closeBtn.addEventListener('click', () => overlay.remove());
+        header.append(title, closeBtn);
+        const content = document.createElement('div');
+        content.style.cssText = 'overflow-y:auto;flex:1;font-size:13px;line-height:1.6;border:1px solid #e2e8f0;border-radius:4px;padding:12px;background:#f8fafc;';
+        content.textContent = 'Running…';
+        box.append(header, content);
+        overlay.appendChild(box);
+        document.body.appendChild(overlay);
+        overlay.addEventListener('click', (e) => { if (e.target === overlay) overlay.remove(); });
+
+        try {
+            const res = await fetch('api.php?action=run_cron_notifications', {
+                method: 'POST',
+                headers: { 'X-CSRF-Token': getCsrfToken() }
+            });
+            const data = await res.json();
+            if (data.status === 'success') {
+                content.innerHTML = data.output;
+            } else {
+                content.textContent = 'Error: ' + (data.error || 'Unknown error');
+                content.style.color = '#991b1b';
+            }
+        } catch (err) {
+            content.textContent = 'Request failed: ' + err.message;
+            content.style.color = '#991b1b';
+        }
+    });
+
     document.getElementById('btnExport').addEventListener('click', () => {
         window.location.href = 'api.php?action=export';
     });

--- a/admin/docs.js
+++ b/admin/docs.js
@@ -17,7 +17,7 @@ export function renderDocumentation(ctx) {
             <p>The admin header exposes the main configuration tabs plus two drop-downs:</p>
             <ul style="padding-left: 20px;">
                 <li><strong>Main tabs:</strong> Schema, Dashboard, Calendar, Workflows, Files.</li>
-                <li><strong>System drop-down:</strong> Database, Security, Users, System Health.</li>
+                <li><strong>System drop-down:</strong> Database, Security, Users, System Health, Run Notifications Cron.</li>
                 <li><strong>Configuration drop-down:</strong> Export / Import the entire configuration as a ZIP archive (recommended before every production deployment).</li>
                 <li><strong>Save config:</strong> Persists the currently edited JSON file to <code>includes/</code>. After a successful save a green status pill appears next to the button confirming which file was written. Error pills stay visible for 6 seconds so they are not missed.</li>
                 <li><strong>Unsaved-changes guard:</strong> The admin panel tracks whether any field has been modified since the last save. Switching to a different tab while there are pending changes shows a confirmation prompt so edits are not silently discarded. The browser also intercepts page reloads and closures when changes are pending.</li>
@@ -41,6 +41,7 @@ export function renderDocumentation(ctx) {
                 <li><code>spw_users</code> — frontend user accounts (id, username, password hash, role, active flag).</li>
                 <li><code>spw_users_log</code> — audit trail of user actions (LOGIN, LOGOUT, CRUD operations).</li>
                 <li><code>spw_users_notifications</code> — per-user in-app notifications, produced by the cron runner.</li>
+                <li><code>spw_users_notifications_log</code> — execution log for the notifications cron: start/end time, status (<code>running</code> / <code>success</code> / <code>error</code>), trigger source (<code>cron</code> or <code>admin</code>), number of sources processed and notifications created, and error message on failure.</li>
                 <li><code>spw_files</code> — metadata for files uploaded through the Files module.</li>
                 <li><code>spw_login_attempts</code> — rolling log used by the DB-backed rate limiter on <code>login.php</code> (IP-hash and username counters).</li>
             </ul>
@@ -145,11 +146,13 @@ export function renderDocumentation(ctx) {
                 <li><strong>Login protection:</strong> <code>login.php</code> applies a DB-backed rate limiter (IP-hash: 20 attempts / 15 min, username: 5 attempts / 15 min) plus CSRF tokens and strict session cookies.</li>
             </ul>
 
-            <h3 style="color: #2563eb; margin-top: 30px;">8. System Health &amp; Backups</h3>
+            <h3 style="color: #2563eb; margin-top: 30px;">8. System Health, Cron &amp; Backups</h3>
             <p>Keep the environment healthy and configuration portable.</p>
             <ul style="padding-left: 20px;">
-                <li><strong>Initialize System Tables:</strong> In the Health tab this creates <code>spw_users</code>, <code>spw_users_log</code>, <code>spw_users_notifications</code>, <code>spw_files</code> and <code>spw_login_attempts</code> inside the configured schema (default <code>app</code>). Run it once on a fresh installation. The call is CSRF-protected via the <code>X-CSRF-Token</code> header.</li>
+                <li><strong>Initialize System Tables:</strong> In the Health tab this creates <code>spw_users</code>, <code>spw_users_log</code>, <code>spw_users_notifications</code>, <code>spw_users_notifications_log</code>, <code>spw_files</code> and <code>spw_login_attempts</code> inside the configured schema (default <code>app</code>). Run it once on a fresh installation and after every upgrade that adds new system tables. The call is CSRF-protected via the <code>X-CSRF-Token</code> header.</li>
                 <li><strong>System diagnostics:</strong> Live checks for PHP version, ZIP / pgsql extensions, write permissions on <code>includes/</code>, and database connectivity.</li>
+                <li><strong>Run Notifications Cron</strong> (System drop-down): Executes <code>cron/cron_notifications.php</code> ad-hoc from the admin panel without waiting for the scheduled task. A modal displays the full execution log in real time. Each run (whether triggered here or by the system scheduler) is recorded in <code>spw_users_notifications_log</code> with timestamp, status, trigger source (<code>admin</code> vs <code>cron</code>), sources processed, notifications created, and any error message. Only users that exist and are active in <code>spw_users</code> receive notifications — stale IDs in the calendar source configuration are silently skipped.</li>
+                <li><strong>Scheduling the cron automatically:</strong> Add a system cron job (e.g. daily at 07:00) to run <code>php /path/to/cron/cron_notifications.php</code>. The script sets the <code>triggered_by</code> flag to <code>cron</code> automatically when called from the command line.</li>
                 <li><strong>Export / Import config:</strong> The <em>Configuration</em> drop-down downloads or uploads a ZIP of all JSON settings. Recommended for backups and migrations to production.</li>
             </ul>
 

--- a/admin/index.php
+++ b/admin/index.php
@@ -136,6 +136,7 @@ if (!isset($_SESSION['sparrow_admin_logged_in']) || $_SESSION['sparrow_admin_log
                     <button class="admin-tab" data-file="security">Security</button>
                     <button class="admin-tab" data-file="users">Users</button>
                     <button class="admin-tab" data-file="health">System Health</button>
+                    <button id="btnRunCron" type="button">Run Notifications Cron</button>
                 </div>
             </div>
             

--- a/cron/cron_notifications.php
+++ b/cron/cron_notifications.php
@@ -24,6 +24,7 @@ function print_log(string $msg): void
 }
 
 require_once __DIR__ . '/../includes/db.php';
+$triggeredBy = (isset($argv[1]) && $argv[1] === 'admin') ? 'admin' : 'cron';
 print_log("<h3>Start CRON - Diagnostics</h3>");
 $configFile = __DIR__ . '/../includes/calendar.json';
 if (!file_exists($configFile)) {
@@ -42,7 +43,11 @@ try {
     print_log("Connecting to the database...");
     $conn = db_connect();
     print_log("Database connected successfully.<br><hr>");
+    $tCronLog = sys_table('users_notifications_log');
+    $logRes = pg_query_params($conn, "INSERT INTO $tCronLog (triggered_by) VALUES ($1) RETURNING id", [$triggeredBy]);
+    $logId = $logRes ? (int) pg_fetch_result($logRes, 0, 0) : null;
     $insertedCount = 0;
+    $sourcesProcessed = 0;
     foreach ($config['sources'] as $source) {
         $table = $source['table'] ?? '';
         $dateCol = $source['date_column'] ?? '';
@@ -55,6 +60,7 @@ try {
             print_log("Skipping source <b>$table</b> (missing required columns or no users assigned).");
             continue;
         }
+        $sourcesProcessed++;
 
         $targetDate = date('Y-m-d', strtotime("+$days days"));
         print_log("Analyzing table: <b>$table</b> (looking for date: <b>$targetDate</b> in column <b>$dateCol</b>)");
@@ -72,6 +78,15 @@ try {
             continue;
         }
 
+        // Resolve only user IDs that actually exist and are active
+        $uidList = '{' . implode(',', array_map('intval', $notifiedUsers)) . '}';
+        $validRes = pg_query_params($conn, "SELECT id FROM " . sys_table('users') . " WHERE id = ANY($1::int[]) AND is_active = TRUE", [$uidList]);
+        $validUserIds = $validRes ? array_map('intval', array_column(pg_fetch_all($validRes) ?: [], 'id')) : [];
+        if (empty($validUserIds)) {
+            print_log("Skipping source <b>$table</b> (none of the configured users exist or are active).");
+            continue;
+        }
+
         $rowCount = pg_num_rows($result);
         print_log("Found matching records in database: <b>$rowCount</b>");
         while ($row = pg_fetch_assoc($result)) {
@@ -79,8 +94,8 @@ try {
         // Prepend target date to the title
             $titleText = $targetDate . ": " . $row['title'];
             $link = str_replace('{id}', (string)$recordId, $urlTemplate);
-        // Insert a notification for every user defined in the array
-            foreach ($notifiedUsers as $userId) {
+        // Insert a notification for every valid user
+            foreach ($validUserIds as $userId) {
                 $userId = (int)$userId;
                 $insertSql = "
                     INSERT INTO " . sys_table('users_notifications') . " (user_id, title, link, source_table, source_id, notify_date)
@@ -100,6 +115,20 @@ try {
     }
 
     print_log("<h3>Finished. NEW notifications generated: $insertedCount</h3>");
+    if ($logId) {
+        pg_query_params(
+            $conn,
+            "UPDATE $tCronLog SET status='success', finished_at=NOW(), sources_processed=$1, notifications_created=$2 WHERE id=$3",
+            [$sourcesProcessed, $insertedCount, $logId]
+        );
+    }
 } catch (Throwable $e) {
     print_log("<span style='color:red;'>Critical error: " . htmlspecialchars($e->getMessage()) . "</span>");
+    if (!empty($logId) && !empty($conn)) {
+        pg_query_params(
+            $conn,
+            "UPDATE $tCronLog SET status='error', finished_at=NOW(), error_message=$1 WHERE id=$2",
+            [substr($e->getMessage(), 0, 2000), $logId]
+        );
+    }
 }

--- a/templates/template.php
+++ b/templates/template.php
@@ -208,13 +208,23 @@
             .then(data => {
                 if (!notifList) return;
                 notifList.innerHTML = '';
-                if (data.length > 0) {
-                    data.forEach(notification => {
+                if (data.notifications && data.notifications.length > 0) {
+                    data.notifications.forEach(notification => {
                         const li = document.createElement('li');
-                        li.style.padding = '15px';
-                        li.style.textAlign = 'center';
-                        li.style.color = '#777';
+                        li.style.cssText = 'padding:10px 15px;border-bottom:1px solid #f0f0f0;font-weight:' + (notification.is_read === 't' ? 'normal' : 'bold') + ';';
                         li.textContent = notification.title;
+                        if (notification.link) {
+                            li.style.cursor = 'pointer';
+                            li.title = notification.link;
+                            li.addEventListener('click', async () => {
+                                await fetch('api_notifications.php?action=mark_read', {
+                                    method: 'POST',
+                                    headers: { 'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest' },
+                                    body: JSON.stringify({ id: parseInt(notification.id) })
+                                }).catch(() => {});
+                                window.location.href = notification.link;
+                            });
+                        }
                         notifList.appendChild(li);
                     });
                 } else {


### PR DESCRIPTION
Fix notification list rendering: wire up link navigation and mark-as-read on click, and validate notified_users against active DB users before inserting. Add ad-hoc Run Notifications Cron action to admin System menu with execution log stored in spw_users_notifications_log.