### PR TITLE
add record snapshot module with admin toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Demo: https://demo.opensparrow.org
 - **Dashboard engine** — COUNT / SUM / AVG / MIN / MAX / GROUP BY widgets defined in `dashboard.json`.
 - **Calendar & notifications** — date-based records on a calendar view, with scheduled reminders via cron.
 - **Admin panel** — visual editors for schema, dashboards, calendar, users at `/admin`. Unified login for all roles — no separate admin password.
-- **Audit logging** — data changes tracked in internal log tables.
+- **Audit logging & record snapshots** — every write is logged to `spw_users_log`; an optional record-snapshot module saves a full JSONB copy of each record after INSERT/UPDATE to `spw_record_snapshots`, toggled from the admin panel or via env var.
 - **CSV export & pagination** — built-in grid utilities.
 - **Workflows builder** — multi-step wizards linking parent/child records across tables.
 - **File management** — per-record attachments with tagging and search, configurable via the admin panel.
@@ -183,6 +183,7 @@ All variables are read by `includes/config.php` on every request — the single 
 |---|---|---|
 | `APP_ENV` | `production` | Runtime environment. |
 | `DEMO_MODE` | `false` | Set `true` to block all write operations in the admin API (safe for public demos). |
+| `RECORD_SNAPSHOTS_ENABLED` | `false` | Enable record snapshot capture after every INSERT/UPDATE. Overrides the admin panel toggle in `includes/settings.json`. |
 | `FILES_MAX_SIZE_MB` | `20` | Default upload size limit when not set in `files.json`. |
 | `THUMBNAIL_MAX_WIDTH` | `300` | Max thumbnail width in pixels. |
 | `NOTIFICATIONS_DROPDOWN_LIMIT` | `10` | Max items in the bell notification dropdown. |

--- a/admin/api.php
+++ b/admin/api.php
@@ -36,7 +36,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 }
 
 // Ensure state-changing actions use POST method to prevent CSRF via GET
-$postActions = ['save', 'import', 'init_db', 'users_add', 'users_toggle', 'users_update_role', 'users_change_password', 'create_table', 'add_column', 'run_cron_notifications', 'backup_tables'];
+$postActions = ['save', 'import', 'init_db', 'users_add', 'users_toggle', 'users_update_role', 'users_change_password', 'create_table', 'add_column', 'run_cron_notifications', 'backup_tables', 'set_snapshot_setting'];
 if (in_array($action, $postActions, true) && $_SERVER['REQUEST_METHOD'] !== 'POST') {
     header('Content-Type: application/json');
     http_response_code(405);
@@ -77,6 +77,7 @@ if ($action === 'init_db') {
         $tFiles = sys_table('files');
         $tLoginAttempts = sys_table('login_attempts');
         $tComments = sys_table('comments');
+        $tRecordSnapshots = sys_table('record_snapshots');
 
         // Prepare missing DB updates and tables creation
         $queries = [
@@ -106,7 +107,11 @@ if ($action === 'init_db') {
             "ALTER TABLE $tUsers ADD COLUMN IF NOT EXISTS avatar_id smallint",
             "CREATE TABLE IF NOT EXISTS $tComments ( id serial4 NOT NULL, related_table varchar(100) NOT NULL, related_id int4 NOT NULL, user_id int4 NOT NULL, body text NOT NULL, created_at timestamp DEFAULT now() NOT NULL, deleted_at timestamp NULL, CONSTRAINT spw_comments_pkey PRIMARY KEY (id), CONSTRAINT spw_comments_body_len CHECK (char_length(body) <= 4000), CONSTRAINT spw_comments_user_id_fkey FOREIGN KEY (user_id) REFERENCES $tUsers(id) ON DELETE SET NULL )",
             "CREATE INDEX IF NOT EXISTS idx_spw_comments_related ON $tComments USING btree (related_table, related_id, created_at)",
-            "CREATE INDEX IF NOT EXISTS idx_spw_comments_user_id ON $tComments USING btree (user_id)"
+            "CREATE INDEX IF NOT EXISTS idx_spw_comments_user_id ON $tComments USING btree (user_id)",
+            "CREATE TABLE IF NOT EXISTS $tRecordSnapshots ( id serial4 NOT NULL, log_id int4 NOT NULL, table_name varchar(100) NOT NULL, record_id int4 NOT NULL, snapshot jsonb NOT NULL, created_at timestamp DEFAULT CURRENT_TIMESTAMP, CONSTRAINT spw_record_snapshots_pkey PRIMARY KEY (id), CONSTRAINT spw_record_snapshots_log_id_fkey FOREIGN KEY (log_id) REFERENCES $tUsersLog(id) ON DELETE CASCADE )",
+            "ALTER TABLE $tRecordSnapshots DROP COLUMN IF EXISTS snapshot_type",
+            "CREATE INDEX IF NOT EXISTS idx_spw_record_snapshots_log_id ON $tRecordSnapshots USING btree (log_id)",
+            "CREATE INDEX IF NOT EXISTS idx_spw_record_snapshots_table_record ON $tRecordSnapshots USING btree (table_name, record_id)"
         ];
         
         foreach ($queries as $q) {
@@ -616,6 +621,78 @@ if ($action === 'list_system_tables') {
     } catch (Exception $e) {
         echo json_encode(['status' => 'error', 'error' => $e->getMessage()]);
     }
+    exit;
+}
+
+// GET: return current record-snapshot setting and whether it is locked by env var
+if ($action === 'get_snapshot_setting') {
+    header('Content-Type: application/json');
+    $envVal = getenv('RECORD_SNAPSHOTS_ENABLED');
+    $lockedByEnv = ($envVal !== false && $envVal !== '');
+    $enabled = false;
+    if ($lockedByEnv) {
+        $enabled = ($envVal === 'true');
+    } else {
+        $settingsFile = __DIR__ . '/../includes/settings.json';
+        if (is_file($settingsFile)) {
+            $raw = @file_get_contents($settingsFile);
+            if ($raw !== false) {
+                $s = @json_decode($raw, true);
+                $enabled = (bool) ($s['record_snapshots_enabled'] ?? false);
+            }
+        }
+    }
+
+    try {
+        require_once __DIR__ . '/../includes/db.php';
+        $conn = @db_connect();
+        $tSnap = sys_table('record_snapshots');
+        $countRes = $conn ? @pg_query($conn, "SELECT COUNT(*) FROM $tSnap") : false;
+        $snapshotCount = ($countRes && ($cr = pg_fetch_row($countRes))) ? (int) $cr[0] : null;
+        $tableExists = ($countRes !== false);
+    } catch (Exception $e) {
+        $snapshotCount = null;
+        $tableExists = false;
+    }
+
+    echo json_encode([
+        'enabled'        => $enabled,
+        'locked_by_env'  => $lockedByEnv,
+        'table_exists'   => $tableExists,
+        'snapshot_count' => $snapshotCount,
+    ]);
+    exit;
+}
+
+// POST: toggle record-snapshot setting in includes/settings.json
+if ($action === 'set_snapshot_setting') {
+    header('Content-Type: application/json');
+    if ($isDemoMode) {
+        echo json_encode(['status' => 'error', 'error' => 'Action disabled in Demo Mode.']);
+        exit;
+    }
+    $envVal = getenv('RECORD_SNAPSHOTS_ENABLED');
+    if ($envVal !== false && $envVal !== '') {
+        echo json_encode(['status' => 'error', 'error' => 'Controlled by RECORD_SNAPSHOTS_ENABLED environment variable — cannot override from admin panel.']);
+        exit;
+    }
+    $body = json_decode(file_get_contents('php://input'), true) ?? [];
+    $enabled = (bool) ($body['enabled'] ?? false);
+    $settingsFile = __DIR__ . '/../includes/settings.json';
+    $settings = [];
+    if (is_file($settingsFile)) {
+        $raw = @file_get_contents($settingsFile);
+        if ($raw !== false) {
+            $settings = @json_decode($raw, true) ?? [];
+        }
+    }
+    $settings['record_snapshots_enabled'] = $enabled;
+    $written = @file_put_contents($settingsFile, json_encode($settings, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+    if ($written === false) {
+        echo json_encode(['status' => 'error', 'error' => 'Could not write includes/settings.json. Check directory permissions.']);
+        exit;
+    }
+    echo json_encode(['status' => 'success', 'enabled' => $enabled]);
     exit;
 }
 

--- a/admin/app.js
+++ b/admin/app.js
@@ -11,6 +11,7 @@ import { renderUsersEditor } from './users.js';
 import { renderWorkflowsEditor } from './workflows.js';
 import { renderFilesEditor } from './files_render.js';
 import { renderBackupPage } from './backup.js';
+import { renderAuditEditor } from './audit.js';
 
 let currentConfig = null;
 let currentFile = 'schema';
@@ -24,7 +25,7 @@ const btnSave = document.getElementById('btnSave');
 const tabs = document.querySelectorAll('.admin-tab');
 
 // Tabs that save immediately via API — no config file involved, never dirty.
-const NON_CONFIG_TABS = new Set(['users', 'security', 'health', 'backup', 'database']);
+const NON_CONFIG_TABS = new Set(['users', 'security', 'health', 'backup', 'database', 'audit']);
 
 // Dirty-state guards: every edit marks the config dirty; navigation and reload
 // refuse to drop pending changes silently.
@@ -212,7 +213,7 @@ function getColumnOptionsForTable(tableName) {
 }
 
 async function loadConfigFile(fileName) {
-    if (fileName === 'health' || fileName === 'docs' || fileName === 'users' || fileName === 'backup' || fileName === 'menu') {
+    if (fileName === 'health' || fileName === 'docs' || fileName === 'users' || fileName === 'backup' || fileName === 'menu' || fileName === 'audit') {
         currentConfig = null;
         renderSidebar();
         renderEditor(fileName.toUpperCase(), null, false);
@@ -294,7 +295,7 @@ function clearConfig() {
 function renderSidebar() {
     itemListEl.innerHTML = '';
     
-    if (currentFile === 'database' || currentFile === 'security' || currentFile === 'health' || currentFile === 'docs' || currentFile === 'users' || currentFile === 'backup' || currentFile === 'menu') {
+    if (currentFile === 'database' || currentFile === 'security' || currentFile === 'health' || currentFile === 'docs' || currentFile === 'users' || currentFile === 'backup' || currentFile === 'menu' || currentFile === 'audit') {
         document.getElementById('sidebarTitle').textContent = currentFile.charAt(0).toUpperCase() + currentFile.slice(1);
         const actionDiv = document.getElementById('sidebarActions');
         if (actionDiv) actionDiv.innerHTML = ''; 
@@ -306,6 +307,7 @@ function renderSidebar() {
         if (currentFile === 'users') title = "System Users";
         if (currentFile === 'backup') title = "Backup Tables";
         if (currentFile === 'menu') title = "View Preview";
+        if (currentFile === 'audit') title = "Audit & Snapshots";
         
         li.textContent = title; 
         li.style.fontWeight = 'bold'; 
@@ -455,7 +457,7 @@ function renderEditor(key, itemData, isArray) {
     workspaceEl.innerHTML = '';
     const ctx = { workspaceEl, currentConfig, getTableOptions, getColumnOptionsForTable, renderEditor, renderSidebar };
     
-    if (['health', 'docs', 'users', 'backup', 'menu'].includes(currentFile) || (currentFile === 'files' && key === 'MANAGER')) {
+    if (['health', 'docs', 'users', 'backup', 'menu', 'audit'].includes(currentFile) || (currentFile === 'files' && key === 'MANAGER')) {
         btnSave.style.display = 'none';
     } else {
         btnSave.style.display = 'inline-block';
@@ -467,6 +469,7 @@ function renderEditor(key, itemData, isArray) {
     if (currentFile === 'docs') return renderDocumentation(ctx);
     if (currentFile === 'users') return renderUsersEditor(ctx);
     if (currentFile === 'backup') return renderBackupPage(ctx);
+    if (currentFile === 'audit') return renderAuditEditor(ctx);
     if (currentFile === 'files' && key === 'MANAGER') return renderFilesEditor(ctx);
 
     if (currentFile === 'menu') {

--- a/admin/audit.js
+++ b/admin/audit.js
@@ -1,0 +1,178 @@
+// This file is part of OpenSparrow - https://opensparrow.org
+// Licensed under LGPL v3. See LICENCE file for details.
+
+// admin/audit.js
+import { showStatusPill } from './app.js';
+
+export async function renderAuditEditor(ctx) {
+    const { workspaceEl } = ctx;
+    workspaceEl.innerHTML = '<h3>Loading audit settings...</h3>';
+
+    let data;
+    try {
+        const res = await fetch('api.php?action=get_snapshot_setting');
+        data = await res.json();
+    } catch (e) {
+        workspaceEl.innerHTML = '<h3 style="color:#ef4444;">Error loading audit settings. Check server logs.</h3>';
+        return;
+    }
+
+    const lockedByEnv = data.locked_by_env ?? false;
+    let enabled = data.enabled ?? false;
+    const tableExists = data.table_exists ?? false;
+    const snapshotCount = data.snapshot_count;
+
+    function getCsrfToken() {
+        return document.querySelector('meta[name="csrf-token"]')?.getAttribute('content') ?? '';
+    }
+
+    workspaceEl.innerHTML = '';
+
+    const h3 = document.createElement('h3');
+    h3.style.marginTop = '0';
+    h3.textContent = 'Audit & Record Snapshots';
+    workspaceEl.appendChild(h3);
+
+    const desc = document.createElement('p');
+    desc.style.cssText = 'color:#64748b; font-size:14px; margin-bottom:24px;';
+    desc.textContent = 'When enabled, every INSERT, UPDATE, and DELETE on user data tables saves a full JSONB snapshot of the record to spw_record_snapshots, linked to the audit log entry in spw_users_log.';
+    workspaceEl.appendChild(desc);
+
+    // --- Status cards ---
+    const grid = document.createElement('div');
+    grid.style.cssText = 'display:grid; gap:10px; margin-bottom:24px;';
+
+    const statusCard = (title, isOk, msg) => {
+        const div = document.createElement('div');
+        div.style.cssText = `padding:12px 16px; border-left:4px solid ${isOk ? '#10b981' : '#ef4444'}; background:white; box-shadow:0 1px 3px rgba(0,0,0,.08); border-radius:4px;`;
+        div.innerHTML = `<strong style="font-size:14px; display:block; margin-bottom:4px; color:${isOk ? '#059669' : '#dc2626'};">${isOk ? '[OK]' : '[FAIL]'} ${title}</strong><span style="color:#475569; font-size:13px;">${msg}</span>`;
+        return div;
+    };
+
+    const infoCard = (title, msg) => {
+        const div = document.createElement('div');
+        div.style.cssText = 'padding:12px 16px; border-left:4px solid #3b82f6; background:white; box-shadow:0 1px 3px rgba(0,0,0,.08); border-radius:4px;';
+        div.innerHTML = `<strong style="font-size:14px; display:block; margin-bottom:4px; color:#1d4ed8;">[INFO] ${title}</strong><span style="color:#475569; font-size:13px;">${msg}</span>`;
+        return div;
+    };
+
+    grid.appendChild(statusCard(
+        'spw_record_snapshots table',
+        tableExists,
+        tableExists
+            ? `Table exists. ${snapshotCount !== null ? `Stored snapshots: <strong>${snapshotCount}</strong>.` : ''}`
+            : 'Table not found. Run <strong>Initialize System Tables</strong> in System Health first.'
+    ));
+
+    if (lockedByEnv) {
+        grid.appendChild(infoCard(
+            'Controlled by environment variable',
+            'The <code>RECORD_SNAPSHOTS_ENABLED</code> env var is set — the toggle below is read-only. Remove the env var to control this setting from the admin panel.'
+        ));
+    }
+
+    workspaceEl.appendChild(grid);
+
+    // --- Toggle ---
+    const toggleSection = document.createElement('div');
+    toggleSection.style.cssText = 'padding:20px; background:white; border:1px solid #e2e8f0; border-radius:8px; margin-bottom:24px;';
+
+    const toggleRow = document.createElement('div');
+    toggleRow.style.cssText = 'display:flex; align-items:center; justify-content:space-between; gap:16px;';
+
+    const labelGroup = document.createElement('div');
+    const labelTitle = document.createElement('strong');
+    labelTitle.style.cssText = 'display:block; font-size:15px; margin-bottom:4px;';
+    labelTitle.textContent = 'Record Snapshots';
+    const labelDesc = document.createElement('span');
+    labelDesc.style.cssText = 'color:#64748b; font-size:13px;';
+    labelDesc.textContent = 'Capture full record state on every write operation and store it in spw_record_snapshots.';
+    labelGroup.appendChild(labelTitle);
+    labelGroup.appendChild(labelDesc);
+
+    const switchLabel = document.createElement('label');
+    switchLabel.style.cssText = 'position:relative; display:inline-block; width:48px; height:26px; flex-shrink:0;';
+
+    const switchInput = document.createElement('input');
+    switchInput.type = 'checkbox';
+    switchInput.checked = enabled;
+    switchInput.disabled = lockedByEnv || !tableExists;
+    switchInput.style.cssText = 'opacity:0; width:0; height:0; position:absolute;';
+
+    const switchSlider = document.createElement('span');
+    switchSlider.style.cssText = `
+        position:absolute; cursor:${lockedByEnv || !tableExists ? 'not-allowed' : 'pointer'};
+        top:0; left:0; right:0; bottom:0;
+        background:${enabled ? '#3b82f6' : '#cbd5e1'};
+        border-radius:26px; transition:background .2s;
+    `;
+    const switchKnob = document.createElement('span');
+    switchKnob.style.cssText = `
+        position:absolute; height:20px; width:20px;
+        left:${enabled ? '24px' : '3px'}; bottom:3px;
+        background:white; border-radius:50%; transition:left .2s;
+        box-shadow:0 1px 3px rgba(0,0,0,.2);
+    `;
+    switchSlider.appendChild(switchKnob);
+    switchLabel.appendChild(switchInput);
+    switchLabel.appendChild(switchSlider);
+
+    const pillAnchor = document.createElement('span');
+
+    switchInput.addEventListener('change', async () => {
+        const newVal = switchInput.checked;
+        switchInput.disabled = true;
+        try {
+            const res = await fetch('api.php?action=set_snapshot_setting', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json', 'X-CSRF-Token': getCsrfToken() },
+                body: JSON.stringify({ enabled: newVal }),
+            });
+            const result = await res.json();
+            if (result.status === 'success') {
+                enabled = newVal;
+                switchSlider.style.background = newVal ? '#3b82f6' : '#cbd5e1';
+                switchKnob.style.left = newVal ? '24px' : '3px';
+                showStatusPill(pillAnchor, newVal ? 'Snapshots enabled' : 'Snapshots disabled', 'success');
+            } else {
+                switchInput.checked = !newVal;
+                showStatusPill(pillAnchor, result.error || 'Error saving setting', 'error');
+            }
+        } catch (e) {
+            switchInput.checked = !newVal;
+            showStatusPill(pillAnchor, 'Request failed', 'error');
+        }
+        switchInput.disabled = lockedByEnv || !tableExists;
+    });
+
+    toggleRow.appendChild(labelGroup);
+    toggleRow.appendChild(switchLabel);
+    toggleSection.appendChild(toggleRow);
+    toggleSection.appendChild(pillAnchor);
+    workspaceEl.appendChild(toggleSection);
+
+    // --- Schema info ---
+    const schemaSection = document.createElement('div');
+    schemaSection.style.cssText = 'padding:16px 20px; background:#f8fafc; border:1px solid #e2e8f0; border-radius:8px;';
+    schemaSection.innerHTML = `
+        <h4 style="margin:0 0 10px; font-size:13px; text-transform:uppercase; letter-spacing:.06em; color:#94a3b8;">Table: spw_record_snapshots</h4>
+        <table style="width:100%; border-collapse:collapse; font-size:13px;">
+            <thead>
+                <tr style="text-align:left; color:#64748b; border-bottom:1px solid #e2e8f0;">
+                    <th style="padding:4px 8px 6px;">Column</th>
+                    <th style="padding:4px 8px 6px;">Type</th>
+                    <th style="padding:4px 8px 6px;">Description</th>
+                </tr>
+            </thead>
+            <tbody style="color:#334155;">
+                <tr><td style="padding:4px 8px;">id</td><td style="padding:4px 8px;">serial</td><td style="padding:4px 8px;">Primary key</td></tr>
+                <tr style="background:#f1f5f9;"><td style="padding:4px 8px;">log_id</td><td style="padding:4px 8px;">int4</td><td style="padding:4px 8px;">FK to spw_users_log.id (CASCADE DELETE)</td></tr>
+                <tr><td style="padding:4px 8px;">table_name</td><td style="padding:4px 8px;">varchar(100)</td><td style="padding:4px 8px;">Name of the affected table</td></tr>
+                <tr><td style="padding:4px 8px;">record_id</td><td style="padding:4px 8px;">int4</td><td style="padding:4px 8px;">PK of the affected record</td></tr>
+                <tr style="background:#f1f5f9;"><td style="padding:4px 8px;">snapshot</td><td style="padding:4px 8px;">jsonb</td><td style="padding:4px 8px;">Full record as JSON (row_to_json)</td></tr>
+                <tr><td style="padding:4px 8px;">created_at</td><td style="padding:4px 8px;">timestamp</td><td style="padding:4px 8px;">When the snapshot was saved</td></tr>
+            </tbody>
+        </table>
+    `;
+    workspaceEl.appendChild(schemaSection);
+}

--- a/admin/docs.js
+++ b/admin/docs.js
@@ -30,7 +30,7 @@ export function renderDocumentation(ctx) {
             <p>The admin header exposes the main configuration tabs plus two drop-downs:</p>
             <ul style="padding-left: 20px;">
                 <li><strong>Main tabs:</strong> Schema, Dashboard, Calendar, Workflows, Files, Menu Preview.</li>
-                <li><strong>System drop-down:</strong> Database, Users, System Health, Backup Tables, Run Notifications Cron.</li>
+                <li><strong>System drop-down:</strong> Database, Users, System Health, Backup Tables, Audit &amp; Snapshots, Run Notifications Cron.</li>
                 <li><strong>Configuration drop-down:</strong> Export / Import the entire configuration as a ZIP archive (recommended before every production deployment).</li>
                 <li><strong>Save config:</strong> Persists the currently edited JSON file to <code>includes/</code>. After a successful save a green status pill appears next to the button confirming which file was written. Error pills stay visible for 6 seconds so they are not missed.</li>
                 <li><strong>Unsaved-changes guard:</strong> Tracks pending changes in config-editing tabs (Schema, Dashboard, Calendar, etc.) and shows a confirmation prompt before discarding them. Tabs that save immediately via API (Users, Database, Health, Backup) never trigger this warning.</li>
@@ -58,6 +58,7 @@ export function renderDocumentation(ctx) {
                 <li><code>spw_files</code> — metadata for files uploaded through the Files module.</li>
                 <li><code>spw_login_attempts</code> — rolling log used by the DB-backed rate limiter on <code>login.php</code> (IP-hash and username counters).</li>
                 <li><code>spw_comments</code> — user comments attached to any record. Each row links to a specific record via <code>related_table</code> + <code>related_id</code>, stores the author (<code>user_id</code>), body text (max 4000 chars), and a soft-delete timestamp.</li>
+                <li><code>spw_record_snapshots</code> — JSONB snapshots of records captured after every INSERT or UPDATE. Each row is linked to the corresponding <code>spw_users_log</code> entry via <code>log_id</code> (CASCADE DELETE). Only active when the Record Snapshots module is enabled (see section 9b).</li>
             </ul>
             <p style="background: #fef3c7; padding: 10px 14px; border-left: 3px solid #f59e0b; border-radius: 4px; font-size: 14px;">
                 <strong>Note:</strong> Tables starting with <code>spw_</code> are treated as system tables. They are <strong>filtered out</strong> from the <em>Sync DB Tables</em> list in the Schema tab and will not appear in your application schema, even if they live in the same PostgreSQL schema as your business tables.
@@ -194,6 +195,30 @@ export function renderDocumentation(ctx) {
                 <li><strong>Export / Import config:</strong> The <em>Configuration</em> drop-down downloads or uploads a ZIP of all JSON settings. Recommended for backups and migrations to production.</li>
             </ul>
 
+            <h3 style="color: #2563eb; margin-top: 30px;">9b. Audit &amp; Record Snapshots</h3>
+            <p>
+                <strong>System → Audit &amp; Snapshots</strong> controls the record snapshot module — an optional extension of the audit trail that captures the full state of a record after every write operation.
+            </p>
+            <ul style="padding-left: 20px;">
+                <li><strong>How it works:</strong> When enabled, every INSERT (via <code>create.php</code> or the grid) and every UPDATE (via <code>edit.php</code> or the inline grid PATCH) saves a JSONB copy of the record's current state to <code>spw_record_snapshots</code>. Each snapshot is linked to the corresponding row in <code>spw_users_log</code> via <code>log_id</code>. DELETE operations are logged to <code>spw_users_log</code> but do not produce a snapshot.</li>
+                <li><strong>Toggle:</strong> The on/off switch writes to <code>includes/settings.json</code>. The setting takes effect on the next request — no server restart required. If the <code>RECORD_SNAPSHOTS_ENABLED</code> environment variable is set, the toggle is read-only (the env var wins).</li>
+                <li><strong>Prerequisite:</strong> Run <em>Initialize System Tables</em> (System → System Health) at least once after upgrading to create the <code>spw_record_snapshots</code> table. The panel shows the table status and current snapshot count.</li>
+                <li><strong>Schema of <code>spw_record_snapshots</code>:</strong>
+                    <ul style="padding-left: 20px; margin-top: 5px;">
+                        <li><code>id</code> — serial primary key.</li>
+                        <li><code>log_id</code> — FK to <code>spw_users_log.id</code> (CASCADE DELETE).</li>
+                        <li><code>table_name</code> — name of the affected table.</li>
+                        <li><code>record_id</code> — primary key of the affected record.</li>
+                        <li><code>snapshot</code> — JSONB: full record state captured with <code>row_to_json()</code> after the write.</li>
+                        <li><code>created_at</code> — timestamp of the snapshot.</li>
+                    </ul>
+                </li>
+                <li><strong>Storage growth:</strong> Every update to a frequently-changed table produces one row in <code>spw_record_snapshots</code>. Monitor table size and implement a retention policy (e.g. a cron job deleting rows older than N days) for high-volume installations.</li>
+            </ul>
+            <p style="background:#f0f9ff;padding:10px 14px;border-left:3px solid #38bdf8;border-radius:4px;font-size:14px;">
+                <strong>Tip:</strong> Use <code>SELECT s.snapshot FROM spw_record_snapshots s JOIN spw_users_log l ON l.id = s.log_id WHERE l.target_table = 'your_table' AND s.record_id = 42 ORDER BY s.created_at DESC</code> to retrieve the full change history of a specific record.
+            </p>
+
             <h3 style="color: #2563eb; margin-top: 30px;">10. Files Module</h3>
             <p>The <strong>Files</strong> tab is a central repository for documents and media, backed by the <code>spw_files</code> table.</p>
             <ul style="padding-left: 20px;">
@@ -312,6 +337,7 @@ export function renderDocumentation(ctx) {
                     <tr><td style="padding:5px 10px;border:1px solid #e2e8f0;"><code>THUMBNAIL_MAX_WIDTH</code></td><td style="padding:5px 10px;border:1px solid #e2e8f0;"><code>300</code></td><td style="padding:5px 10px;border:1px solid #e2e8f0;">Max thumbnail width in pixels.</td></tr>
                     <tr><td style="padding:5px 10px;border:1px solid #e2e8f0;"><code>NOTIFICATIONS_DROPDOWN_LIMIT</code></td><td style="padding:5px 10px;border:1px solid #e2e8f0;"><code>10</code></td><td style="padding:5px 10px;border:1px solid #e2e8f0;">Max items shown in the bell notification dropdown.</td></tr>
                     <tr><td style="padding:5px 10px;border:1px solid #e2e8f0;"><code>HSTS_MAX_AGE</code></td><td style="padding:5px 10px;border:1px solid #e2e8f0;"><code>31536000</code></td><td style="padding:5px 10px;border:1px solid #e2e8f0;">HSTS max-age in seconds (1 year). Set <code>0</code> to disable on plain HTTP.</td></tr>
+                    <tr><td style="padding:5px 10px;border:1px solid #e2e8f0;"><code>RECORD_SNAPSHOTS_ENABLED</code></td><td style="padding:5px 10px;border:1px solid #e2e8f0;"><code>false</code></td><td style="padding:5px 10px;border:1px solid #e2e8f0;">Enable record snapshots system-wide. When set, overrides the admin panel toggle in <code>includes/settings.json</code>.</td></tr>
                     <tr><td style="padding:5px 10px;border:1px solid #e2e8f0;"><code>PGDATABASE</code></td><td style="padding:5px 10px;border:1px solid #e2e8f0;">—</td><td style="padding:5px 10px;border:1px solid #e2e8f0;">PostgreSQL database name.</td></tr>
                     <tr><td style="padding:5px 10px;border:1px solid #e2e8f0;"><code>PGUSER</code></td><td style="padding:5px 10px;border:1px solid #e2e8f0;">—</td><td style="padding:5px 10px;border:1px solid #e2e8f0;">PostgreSQL user.</td></tr>
                     <tr><td style="padding:5px 10px;border:1px solid #e2e8f0;"><code>PGPASSWORD</code></td><td style="padding:5px 10px;border:1px solid #e2e8f0;">—</td><td style="padding:5px 10px;border:1px solid #e2e8f0;">PostgreSQL password.</td></tr>

--- a/admin/index.php
+++ b/admin/index.php
@@ -120,6 +120,7 @@ if (empty($_SESSION['csrf_token'])) {
                     <button class="admin-tab" data-file="users">Users</button>
                     <button class="admin-tab" data-file="health">System Health</button>
                     <button class="admin-tab" data-file="backup">Backup Tables</button>
+                    <button class="admin-tab" data-file="audit">Audit &amp; Snapshots</button>
                     <button id="btnRunCron" type="button">Run Notifications Cron</button>
                 </div>
             </div>

--- a/admin/mockup.html
+++ b/admin/mockup.html
@@ -1,0 +1,590 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Sparrow Admin - Redesign Mockup</title>
+    <style>
+        :root {
+            --bg: #F4F7F9;
+            --panel: #ffffff;
+            --text: #1E293B;
+            --muted: #64748B;
+            --accent: #005A9E;
+            --accent-dark: #003366;
+            --accent-light: #F0F6FA;
+            --accent-mid: #DDEAF4;
+            --danger: #DC2626;
+            --ok: #16A34A;
+            --border: #CBD5E1;
+            --border-light: #E2E8F0;
+            --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.05);
+            --shadow-md: 0 4px 6px -1px rgba(0, 0, 0, 0.1);
+            --radius: 6px;
+            --header-h: 60px;
+            --sidebar-w: 280px;
+            --transition: 150ms ease;
+        }
+
+        /* Icons */
+        .icon {
+            width: 18px;
+            height: 18px;
+            display: inline-block;
+            flex-shrink: 0;
+            filter: brightness(0.4);
+        }
+
+        .btn-header .icon {
+            filter: brightness(0) invert(1);
+        }
+
+        .sidebar-section-icon {
+            width: 18px;
+            height: 18px;
+            flex-shrink: 0;
+        }
+
+        .sidebar-item-icon {
+            width: 16px;
+            height: 16px;
+            flex-shrink: 0;
+        }
+
+        * {
+            box-sizing: border-box;
+        }
+
+        body {
+            margin: 0;
+            padding: 0;
+            background-color: var(--bg);
+            color: var(--text);
+            font-family: 'Inter', system-ui, -apple-system, sans-serif;
+            -webkit-font-smoothing: antialiased;
+        }
+
+        /* ─────────────────────────────────────────────────────────────── */
+        /* Header */
+        /* ─────────────────────────────────────────────────────────────── */
+        header {
+            background-color: var(--accent-dark);
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            padding: 0 20px;
+            height: var(--header-h);
+            box-shadow: var(--shadow-sm);
+            color: white;
+        }
+
+        .header-brand {
+            display: flex;
+            align-items: center;
+            gap: 12px;
+            font-weight: 600;
+            font-size: 18px;
+        }
+
+        .header-brand img {
+            width: 32px;
+            height: 32px;
+        }
+
+        .header-actions {
+            display: flex;
+            align-items: center;
+            gap: 12px;
+        }
+
+        .btn-header {
+            background: rgba(255, 255, 255, 0.1);
+            color: white;
+            border: 1px solid rgba(255, 255, 255, 0.2);
+            padding: 6px 12px;
+            border-radius: var(--radius);
+            cursor: pointer;
+            font-size: 13px;
+            font-weight: 500;
+            transition: all var(--transition);
+            display: flex;
+            align-items: center;
+            gap: 6px;
+        }
+
+        .btn-header:hover {
+            background: rgba(255, 255, 255, 0.15);
+            border-color: rgba(255, 255, 255, 0.3);
+        }
+
+        .btn-danger {
+            background: var(--danger);
+            border-color: var(--danger);
+        }
+
+        .btn-danger:hover {
+            background: #b91c1c;
+        }
+
+        /* ─────────────────────────────────────────────────────────────── */
+        /* Main layout */
+        /* ─────────────────────────────────────────────────────────────── */
+        .container {
+            display: flex;
+            height: calc(100vh - var(--header-h));
+            width: 100%;
+        }
+
+        /* ─────────────────────────────────────────────────────────────── */
+        /* Sidebar */
+        /* ─────────────────────────────────────────────────────────────── */
+        .sidebar {
+            flex: 0 0 var(--sidebar-w);
+            width: var(--sidebar-w);
+            background-color: var(--panel);
+            border-right: 1px solid var(--border);
+            overflow-y: auto;
+            display: flex;
+            flex-direction: column;
+            transition: transform var(--transition);
+        }
+
+        .sidebar.collapsed {
+            transform: translateX(calc(-1 * var(--sidebar-w)));
+            position: absolute;
+            z-index: 50;
+            box-shadow: var(--shadow-md);
+        }
+
+        .sidebar-toggle {
+            display: none;
+            position: absolute;
+            top: 70px;
+            left: 10px;
+            z-index: 60;
+            background: var(--accent);
+            color: white;
+            border: none;
+            padding: 6px 8px;
+            border-radius: var(--radius);
+            cursor: pointer;
+            font-size: 16px;
+        }
+
+        .sidebar.collapsed ~ .sidebar-toggle {
+            display: block;
+        }
+
+        .sidebar-content {
+            flex: 1;
+            padding: 20px 12px;
+        }
+
+        .sidebar-section {
+            margin-bottom: 24px;
+        }
+
+        .sidebar-section-title {
+            display: flex;
+            align-items: center;
+            gap: 8px;
+            padding: 12px;
+            margin-bottom: 8px;
+            cursor: pointer;
+            user-select: none;
+            font-weight: 600;
+            font-size: 13px;
+            color: var(--text);
+            text-transform: uppercase;
+            letter-spacing: 0.5px;
+            transition: all var(--transition);
+        }
+
+        .sidebar-section-title:hover {
+            color: var(--accent);
+        }
+
+        .sidebar-section-toggle {
+            margin-left: auto;
+            transition: transform var(--transition);
+            font-size: 12px;
+        }
+
+        .sidebar-section.open .sidebar-section-toggle {
+            transform: rotate(180deg);
+        }
+
+        .sidebar-items {
+            display: none;
+            padding-left: 8px;
+        }
+
+        .sidebar-section.open .sidebar-items {
+            display: block;
+        }
+
+        .sidebar-item {
+            display: flex;
+            align-items: center;
+            gap: 10px;
+            padding: 10px 12px;
+            margin-bottom: 4px;
+            cursor: pointer;
+            border-radius: var(--radius);
+            color: var(--muted);
+            font-size: 14px;
+            transition: all var(--transition);
+            min-height: 36px;
+        }
+
+        .sidebar-item:hover {
+            background-color: var(--accent-light);
+            color: var(--accent);
+        }
+
+        .sidebar-item.active {
+            background-color: var(--accent-light);
+            color: var(--accent);
+            font-weight: 600;
+            border-left: 3px solid var(--accent);
+            padding-left: 9px;
+        }
+
+        .sidebar-divider {
+            height: 1px;
+            background-color: var(--border-light);
+            margin: 12px 0;
+        }
+
+        /* ─────────────────────────────────────────────────────────────── */
+        /* Main workspace */
+        /* ─────────────────────────────────────────────────────────────── */
+        .workspace {
+            flex: 1;
+            display: flex;
+            flex-direction: column;
+            overflow: hidden;
+        }
+
+        .breadcrumb {
+            background-color: var(--panel);
+            border-bottom: 1px solid var(--border-light);
+            padding: 12px 30px;
+            font-size: 13px;
+            color: var(--muted);
+        }
+
+        .breadcrumb a {
+            color: var(--accent);
+            text-decoration: none;
+            cursor: pointer;
+        }
+
+        .breadcrumb a:hover {
+            text-decoration: underline;
+        }
+
+        .content {
+            flex: 1;
+            padding: 30px;
+            overflow-y: auto;
+            background-color: var(--bg);
+        }
+
+        .content h1 {
+            margin-top: 0;
+            margin-bottom: 8px;
+            font-size: 28px;
+            color: var(--text);
+        }
+
+        .content-description {
+            color: var(--muted);
+            font-size: 14px;
+            margin-bottom: 30px;
+        }
+
+        /* ─────────────────────────────────────────────────────────────── */
+        /* Cards (mockup content) */
+        /* ─────────────────────────────────────────────────────────────── */
+        .card {
+            background: var(--panel);
+            border: 1px solid var(--border-light);
+            padding: 20px;
+            border-radius: var(--radius);
+            box-shadow: var(--shadow-sm);
+            margin-bottom: 20px;
+        }
+
+        .card h3 {
+            margin-top: 0;
+            color: var(--text);
+            display: flex;
+            align-items: center;
+            gap: 8px;
+        }
+
+        .card p {
+            color: var(--muted);
+            margin-bottom: 0;
+        }
+
+        /* ─────────────────────────────────────────────────────────────── */
+        /* Preview container */
+        /* ─────────────────────────────────────────────────────────────── */
+        .mockup-note {
+            background-color: #fef3c7;
+            border: 1px solid #fcd34d;
+            padding: 12px 16px;
+            border-radius: var(--radius);
+            font-size: 13px;
+            color: #92400e;
+            margin-bottom: 20px;
+            display: flex;
+            align-items: center;
+            gap: 8px;
+        }
+
+        /* Responsive */
+        @media (max-width: 768px) {
+            .sidebar {
+                position: fixed;
+                height: calc(100vh - var(--header-h));
+                z-index: 40;
+                transform: translateX(calc(-1 * var(--sidebar-w)));
+            }
+
+            .sidebar.active {
+                transform: translateX(0);
+            }
+
+            .sidebar-toggle {
+                display: block;
+            }
+        }
+    </style>
+</head>
+<body>
+    <!-- Header -->
+    <header>
+        <div class="header-brand">
+            <svg width="32" height="32" viewBox="0 0 32 32" fill="none" style="flex-shrink: 0;">
+                <rect width="32" height="32" rx="6" fill="#DCE5ED"/>
+                <path d="M8 16C8 11.6 11.6 8 16 8C20.4 8 24 11.6 24 16" stroke="#005A9E" stroke-width="2" stroke-linecap="round"/>
+                <circle cx="16" cy="16" r="3" fill="#005A9E"/>
+            </svg>
+            <span>Sparrow Admin</span>
+        </div>
+        <div class="header-actions">
+            <label style="color: white; font-size: 13px; display: flex; align-items: center; gap: 6px; cursor: pointer;">
+                <input type="checkbox" style="width: 14px; height: 14px;">
+                Debug
+            </label>
+            <button class="btn-header" title="Documentation">
+                <img class="icon" src="../assets/icons/book_3s.png" alt="Docs">
+                Docs
+            </button>
+            <button class="btn-header" title="User Menu">
+                <img class="icon" src="../assets/icons/person.png" alt="User">
+                User
+            </button>
+            <button class="btn-header btn-danger" title="Logout">
+                <span style="font-size: 16px;">⊗</span>
+                Logout
+            </button>
+        </div>
+    </header>
+
+    <!-- Main container -->
+    <div class="container">
+        <!-- Sidebar -->
+        <aside class="sidebar" id="sidebar">
+            <div class="sidebar-content">
+                <!-- Data Management Section -->
+                <div class="sidebar-section open">
+                    <div class="sidebar-section-title" onclick="toggleSection(this)">
+                        <img class="sidebar-section-icon" src="../assets/icons/dashboard.png" alt="Data">
+                        <span>Data Management</span>
+                        <span class="sidebar-section-toggle">▼</span>
+                    </div>
+                    <div class="sidebar-items">
+                        <div class="sidebar-item active">
+                            <img class="sidebar-item-icon" src="../assets/icons/table_chart_view.png" alt="Schema">
+                            <span>Schema</span>
+                        </div>
+                        <div class="sidebar-item">
+                            <img class="sidebar-item-icon" src="../assets/icons/bar_chart.png" alt="Dashboard">
+                            <span>Dashboard</span>
+                        </div>
+                        <div class="sidebar-item">
+                            <img class="sidebar-item-icon" src="../assets/icons/calendar.png" alt="Calendar">
+                            <span>Calendar</span>
+                        </div>
+                        <div class="sidebar-item">
+                            <img class="sidebar-item-icon" src="../assets/icons/files.png" alt="Files">
+                            <span>Files</span>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Workflows Section -->
+                <div class="sidebar-section open">
+                    <div class="sidebar-section-title" onclick="toggleSection(this)">
+                        <img class="sidebar-section-icon" src="../assets/icons/automation.png" alt="Workflows">
+                        <span>Workflows</span>
+                        <span class="sidebar-section-toggle">▼</span>
+                    </div>
+                    <div class="sidebar-items">
+                        <div class="sidebar-item">
+                            <img class="sidebar-item-icon" src="../assets/icons/automation.png" alt="Manager">
+                            <span>Workflow Manager</span>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- System Section -->
+                <div class="sidebar-section open">
+                    <div class="sidebar-section-title" onclick="toggleSection(this)">
+                        <img class="sidebar-section-icon" src="../assets/icons/computer.png" alt="System">
+                        <span>System</span>
+                        <span class="sidebar-section-toggle">▼</span>
+                    </div>
+                    <div class="sidebar-items">
+                        <div class="sidebar-item">
+                            <img class="sidebar-item-icon" src="../assets/icons/computer.png" alt="Database">
+                            <span>Database</span>
+                        </div>
+                        <div class="sidebar-item">
+                            <img class="sidebar-item-icon" src="../assets/icons/person.png" alt="Users">
+                            <span>Users</span>
+                        </div>
+                        <div class="sidebar-item">
+                            <img class="sidebar-item-icon" src="../assets/icons/watch_screentime.png" alt="Health">
+                            <span>Health Check</span>
+                        </div>
+                        <div class="sidebar-item">
+                            <img class="sidebar-item-icon" src="../assets/icons/folder_zip.png" alt="Backup">
+                            <span>Backup</span>
+                        </div>
+                        <div class="sidebar-item">
+                            <img class="sidebar-item-icon" src="../assets/icons/id_card.png" alt="Security">
+                            <span>Security</span>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Configuration Section -->
+                <div class="sidebar-section open">
+                    <div class="sidebar-section-title" onclick="toggleSection(this)">
+                        <img class="sidebar-section-icon" src="../assets/icons/package_2.png" alt="Config">
+                        <span>Configuration</span>
+                        <span class="sidebar-section-toggle">▼</span>
+                    </div>
+                    <div class="sidebar-items">
+                        <div class="sidebar-item">
+                            <img class="sidebar-item-icon" src="../assets/icons/folder_zip.png" alt="Import">
+                            <span>Import Config</span>
+                        </div>
+                        <div class="sidebar-item">
+                            <img class="sidebar-item-icon" src="../assets/icons/folder_zip.png" alt="Export">
+                            <span>Export Config</span>
+                        </div>
+                        <div class="sidebar-item">
+                            <img class="sidebar-item-icon" src="../assets/icons/autorenew.png" alt="Cron">
+                            <span>Run Cron</span>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="sidebar-divider"></div>
+
+                <!-- Quick Links -->
+                <div class="sidebar-section" style="margin-bottom: 0;">
+                    <div class="sidebar-section-title" style="cursor: default; color: var(--muted);">
+                        <svg style="width: 14px; height: 14px; flex-shrink: 0;" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2Z"/></svg>
+                        <span style="font-size: 11px; text-transform: none; font-weight: 500;">Favorites</span>
+                    </div>
+                    <div class="sidebar-items" style="display: block;">
+                        <div class="sidebar-item">
+                            <img class="sidebar-item-icon" src="../assets/icons/person.png" alt="users">
+                            <span>users (Schema)</span>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </aside>
+
+        <button class="sidebar-toggle" onclick="toggleSidebar()">☰</button>
+
+        <!-- Workspace -->
+        <div class="workspace">
+            <!-- Breadcrumb -->
+            <div class="breadcrumb">
+                <a>Dashboard</a> /
+                <a>Data Management</a> /
+                <a>Schema</a> /
+                <strong>users (table)</strong>
+            </div>
+
+            <!-- Content -->
+            <div class="content">
+                <h1>Schema Editor</h1>
+                <p class="content-description">Edit database table structures, columns, and constraints.</p>
+
+                <div class="mockup-note">
+                    <strong>ℹ️ Mockup view:</strong> Pokazuje nową strukturę navigacji. Sekcje można zwijać/rozwijać (kliknij na tytuł).
+                </div>
+
+                <div class="card">
+                    <h3>
+                        <img class="icon" src="../assets/icons/table_chart_view.png" alt="users">
+                        users Table
+                    </h3>
+                    <p><strong>Columns:</strong> id, email, password, role, created_at, updated_at</p>
+                    <p><strong>Status:</strong> ✓ Synced with database</p>
+                </div>
+
+                <div class="card">
+                    <h3>
+                        <svg style="width: 18px; height: 18px; flex-shrink: 0;" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="12 1 3 5 3 19 12 23 21 19 21 5 12 1"></polyline><polyline points="12 12 3 7"></polyline><polyline points="12 23 12 12"></polyline><line x1="12" y1="12" x2="21" y2="7"></line></svg>
+                        Zalety nowego layoutu
+                    </h3>
+                    <ul style="color: var(--muted); margin: 0; padding-left: 20px;">
+                        <li>✅ Jasna hierarchia funkcji (Data → System → Config)</li>
+                        <li>✅ Sidebar głównym sposobem nawigacji (jak WordPress/Drupal)</li>
+                        <li>✅ Ikony z assets/icons/ dla consistency</li>
+                        <li>✅ Sekcje zwijane oszczędzają przestrzeń</li>
+                        <li>✅ Breadcrumbs orientują gdzie jesteś</li>
+                        <li>✅ Header uproszczony do essentials</li>
+                        <li>✅ Favorites/Recently used pinning</li>
+                        <li>✅ Responsywny na mobile (sidebar drawer)</li>
+                    </ul>
+                </div>
+
+                <div class="card">
+                    <h3>
+                        <svg style="width: 18px; height: 18px; flex-shrink: 0;" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M13 10V3L4 14h7v7l9-11h-7Z"></path></svg>
+                        Next steps
+                    </h3>
+                    <p><strong>1.</strong> Dodać search do sidebar'a (szukaj tabeli/widgetu)</p>
+                    <p><strong>2.</strong> Animacje collapse/expand (smooth transitions)</p>
+                    <p><strong>3.</strong> Save button context-aware (tylko gdy editing config)</p>
+                    <p style="margin-bottom: 0;"><strong>4.</strong> Wdrożyć w admin/index.php</p>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <script>
+        function toggleSection(titleEl) {
+            const section = titleEl.closest('.sidebar-section');
+            section.classList.toggle('open');
+        }
+
+        function toggleSidebar() {
+            const sidebar = document.getElementById('sidebar');
+            sidebar.classList.toggle('collapsed');
+        }
+    </script>
+</body>
+</html>

--- a/admin/users.js
+++ b/admin/users.js
@@ -234,8 +234,6 @@ export async function renderUsersEditor(ctx) {
                 overlay.appendChild(box);
                 document.body.appendChild(overlay);
 
-                const msgEl    = box.querySelector('#cpw-msg');
-                const newInput = box.querySelector('#cpw-new');
                 (box.querySelector('#cpw-current') ?? newInput).focus();
 
                 box.querySelector('#cpw-cancel').addEventListener('click', () => overlay.remove());

--- a/api.php
+++ b/api.php
@@ -612,7 +612,10 @@ try {
                 exit;
             }
 
-            log_user_action($conn, (int)$_SESSION['user_id'], 'UPDATE', $table, (int)$body['id']);
+            $logId = log_user_action($conn, (int)$_SESSION['user_id'], 'UPDATE', $table, (int)$body['id']);
+            if (RECORD_SNAPSHOTS_ENABLED && $logId !== null) {
+                snapshot_record($conn, $schemaName, $table, (int) $body['id'], $logId);
+            }
             echo json_encode(['ok' => true]);
             exit;
         }
@@ -683,7 +686,10 @@ try {
             $newId = $row[$idCol] ?? null;
 
             if ($newId !== null) {
-                log_user_action($conn, (int)$_SESSION['user_id'], 'INSERT', $table, (int)$newId);
+                $logId = log_user_action($conn, (int)$_SESSION['user_id'], 'INSERT', $table, (int)$newId);
+                if (RECORD_SNAPSHOTS_ENABLED && $logId !== null) {
+                    snapshot_record($conn, $schemaName, $table, (int) $newId, $logId);
+                }
             }
 
             echo json_encode(['ok' => true, 'id' => $newId]);

--- a/create.php
+++ b/create.php
@@ -35,7 +35,10 @@ if ($request->isPost()) {
     try {
         $data  = $mapper->fromPost($tableCfg, $request->postAll());
         $newId = $records->insert($tableCfg, $data);
-        $audit->log($session->userId(), 'INSERT', $tableCfg->name, (int)$newId);
+        $logId = $audit->log($session->userId(), 'INSERT', $tableCfg->name, (int)$newId);
+        if (RECORD_SNAPSHOTS_ENABLED && $logId !== null) {
+            snapshot_record($GLOBALS['conn'], $tableCfg->schema, $tableCfg->name, (int)$newId, $logId);
+        }
         header('Location: index.php?table=' . urlencode($table));
         exit;
     } catch (\RuntimeException $e) {

--- a/edit.php
+++ b/edit.php
@@ -35,9 +35,12 @@ if ($request->isPost()) {
         die('Invalid CSRF token.');
     }
     try {
-        $data = $mapper->fromPost($tableCfg, $request->postAll());
+        $data  = $mapper->fromPost($tableCfg, $request->postAll());
         $records->update($tableCfg, $id, $data);
-        $audit->log($session->userId(), 'UPDATE', $tableCfg->name, (int)$id);
+        $logId = $audit->log($session->userId(), 'UPDATE', $tableCfg->name, (int)$id);
+        if (RECORD_SNAPSHOTS_ENABLED && $logId !== null) {
+            snapshot_record($GLOBALS['conn'], $tableCfg->schema, $tableCfg->name, (int)$id, $logId);
+        }
         header('Location: index.php?table=' . urlencode($table));
         exit;
     } catch (\RuntimeException $e) {

--- a/includes/api_helpers.php
+++ b/includes/api_helpers.php
@@ -130,9 +130,46 @@ function type_min_value(string $type)
     return '';
 }
 
-// Log action to db
-function log_user_action($conn, int $userId, string $action, ?string $targetTable = null, ?int $recordId = null): void
+// Log action to db — returns the new log row id so callers can attach snapshots.
+function log_user_action($conn, int $userId, string $action, ?string $targetTable = null, ?int $recordId = null): ?int
 {
-    $sql = 'INSERT INTO ' . sys_table('users_log') . ' (user_id, action, target_table, record_id) VALUES ($1, $2, $3, $4)';
-    @pg_query_params($conn, $sql, [$userId, $action, $targetTable, $recordId]);
+    $sql = 'INSERT INTO ' . sys_table('users_log')
+         . ' (user_id, action, target_table, record_id) VALUES ($1, $2, $3, $4) RETURNING id';
+    $res = @pg_query_params($conn, $sql, [$userId, $action, $targetTable, $recordId]);
+    if ($res && ($row = pg_fetch_row($res))) {
+        return (int) $row[0];
+    }
+    return null;
+}
+
+// Fetch a single record as a JSON string using row_to_json().
+// row_to_json requires SELECT * to capture all columns dynamically regardless of schema.
+function fetch_record_json($conn, string $schemaName, string $table, int $recordId): ?string
+{
+    $safeRef = pg_ident($schemaName) . '.' . pg_ident($table);
+    $res = pg_query_params(
+        $conn,
+        "SELECT row_to_json(t) FROM (SELECT * FROM {$safeRef} WHERE id = \$1) t",
+        [$recordId]
+    );
+    if (!$res) {
+        return null;
+    }
+    $row = pg_fetch_row($res);
+    return ($row && $row[0] !== null) ? $row[0] : null;
+}
+
+// Save a JSONB snapshot of the current record state linked to a log entry.
+function snapshot_record($conn, string $schemaName, string $table, int $recordId, int $logId): void
+{
+    $json = fetch_record_json($conn, $schemaName, $table, $recordId);
+    if ($json === null) {
+        return;
+    }
+    @pg_query_params(
+        $conn,
+        'INSERT INTO ' . sys_table('record_snapshots')
+            . ' (log_id, table_name, record_id, snapshot) VALUES ($1, $2, $3, $4)',
+        [$logId, $table, $recordId, $json]
+    );
 }

--- a/includes/config.php
+++ b/includes/config.php
@@ -146,3 +146,26 @@ define('CONFIG_FILE_MAX_BYTES', (int) get_env('CONFIG_FILE_MAX_BYTES', '524288')
 // max-age value (in seconds) for the Strict-Transport-Security header.
 // Default is 1 year (31 536 000 s). Set to 0 to disable HSTS on plain HTTP.
 define('HSTS_MAX_AGE', (int) get_env('HSTS_MAX_AGE', '31536000'));
+
+// -------------------------------------------------------------------------
+// Audit & record snapshots
+// -------------------------------------------------------------------------
+
+// When true, a JSONB snapshot of every inserted/updated/deleted record is
+// saved to spw_record_snapshots and linked to the corresponding audit log entry.
+// Can be toggled at runtime via Admin → System → Audit & Snapshots.
+// The RECORD_SNAPSHOTS_ENABLED env var takes precedence over the settings file.
+define('RECORD_SNAPSHOTS_ENABLED', (function (): bool {
+    $env = get_env('RECORD_SNAPSHOTS_ENABLED', '');
+    if ($env !== '') {
+        return $env === 'true';
+    }
+    $f = __DIR__ . '/settings.json';
+    if (is_file($f)) {
+        $s = @json_decode((string) file_get_contents($f), true);
+        if (is_array($s) && array_key_exists('record_snapshots_enabled', $s)) {
+            return (bool) $s['record_snapshots_enabled'];
+        }
+    }
+    return false;
+})());

--- a/src/Audit/AuditLoggerInterface.php
+++ b/src/Audit/AuditLoggerInterface.php
@@ -6,5 +6,5 @@ namespace App\Audit;
 
 interface AuditLoggerInterface
 {
-    public function log(int $userId, string $action, string $table, int $recordId): void;
+    public function log(int $userId, string $action, string $table, int $recordId): ?int;
 }

--- a/src/Audit/DbAuditLogger.php
+++ b/src/Audit/DbAuditLogger.php
@@ -12,10 +12,14 @@ final class DbAuditLogger implements AuditLoggerInterface
     {
     }
 
-    public function log(int $userId, string $action, string $table, int $recordId): void
+    public function log(int $userId, string $action, string $table, int $recordId): ?int
     {
         $sql = 'INSERT INTO ' . sys_table('users_log')
-             . ' (user_id, action, target_table, record_id) VALUES ($1, $2, $3, $4)';
-        @pg_query_params($this->conn->native(), $sql, [$userId, $action, $table, $recordId]);
+             . ' (user_id, action, target_table, record_id) VALUES ($1, $2, $3, $4) RETURNING id';
+        $res = @pg_query_params($this->conn->native(), $sql, [$userId, $action, $table, $recordId]);
+        if ($res && ($row = pg_fetch_row($res))) {
+            return (int) $row[0];
+        }
+        return null;
     }
 }


### PR DESCRIPTION
Add spw_record_snapshots table storing JSONB post-write state for every
INSERT and UPDATE, linked via FK to spw_users_log. Toggle controlled at
runtime via System → Audit & Snapshots (writes includes/settings.json)
or RECORD_SNAPSHOTS_ENABLED env var. Covers both api.php inline edits
and edit.php / create.php OOP path. Fix duplicate const declarations in
users.js that blocked the admin panel from loading.